### PR TITLE
Iterative replacement no runtime

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -249,6 +249,14 @@
       "appTemplate": "step-functions-sample-app"
     }
   ],
+  "none": [
+    {
+      "directory": "none/cookiecutter-step-functions-only",
+      "displayName": "Step Functions only (no Lambda functions)",
+      "dependencyManager": "none",
+      "appTemplate": "step-functions-only"
+    }
+  ],
   "python2.7": [
     {
       "directory": "python2.7/cookiecutter-aws-sam-hello-python",

--- a/manifest.json
+++ b/manifest.json
@@ -255,6 +255,12 @@
       "displayName": "Step Functions only (no Lambda functions)",
       "dependencyManager": "none",
       "appTemplate": "step-functions-only"
+    },
+    {
+      "directory": "none/cookiecutter-iterative-replacement-no-runtime",
+      "displayName": "Monolith migration with iterative replacement (no Lambda functions)",
+      "dependencyManager": "none",
+      "appTemplate": "iterative-replacement"
     }
   ],
   "python2.7": [

--- a/none/cookiecutter-iterative-replacement-no-runtime/.gitignore
+++ b/none/cookiecutter-iterative-replacement-no-runtime/.gitignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/none/cookiecutter-iterative-replacement-no-runtime/CONTRIBUTING.md
+++ b/none/cookiecutter-iterative-replacement-no-runtime/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to this project. Whether it's a bug report, new feature, correction, or additional
+documentation, we greatly value feedback and contributions from our community.
+
+Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
+information to effectively respond to your bug report or contribution.
+
+## Reporting Bugs/Feature Requests
+
+We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+
+When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
+reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+
+* A reproducible test case or series of steps
+* The version of our code being used
+* Any modifications you've made relevant to the bug
+* Anything unusual about your environment or deployment
+
+## Contributing via Pull Requests
+Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+
+1. You are working against the latest source on the *mainline* branch.
+2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
+3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+
+To send us a pull request, please:
+
+1. Fork the repository.
+2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
+3. Ensure local tests pass.
+4. Commit to your fork using clear commit messages.
+5. Send us a pull request, answering any default questions in the pull request interface.
+6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+
+GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+
+## Finding contributions to work on
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
+
+## Licensing
+
+See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+
+We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/none/cookiecutter-iterative-replacement-no-runtime/LICENSE
+++ b/none/cookiecutter-iterative-replacement-no-runtime/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Rob Sutter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/none/cookiecutter-iterative-replacement-no-runtime/README.md
+++ b/none/cookiecutter-iterative-replacement-no-runtime/README.md
@@ -1,0 +1,50 @@
+# AWS SAM iterative replacement template for Go
+
+This repository contains an AWS SAM iterative replacement template. Iterative replacement allows you to migrate a monolith one route at a time by placing an [Amazon API Gateway][api-gateway] [HTTP API][http-api] in front of your existing application. Once all traffic is proxied through your HTTP API, you rewrite routes one at a time to serverless components. This enables you to modernize your monolith while reducing risk.
+
+This template takes a single parameter, `PassthroughTarget`, of the form _https://api.anycompany.com_. Note that there is no trailing forward slash at the end of the target.
+
+This template produces a single output, `APIRoot`, which is the root URL of your new HTTP API.
+
+This template also includes two routes and an [Amazon DynamoDB][dynamodb] table to get you started:
+
+1. POST _/customer_ to create a new record
+1. GET _/customer/{id}_ to retrieve a record
+
+These routes are integrated with two separate [AWS Lambda][lambda] functions, _customer-read_ and _customer-write_. These functions execute with AWS SAM policy templates that appropriately restrict their access to the DynamoDB table.
+
+## How to use this template
+
+1. Install the [AWS SAM CLI][aws-sam-cli]
+1. From a terminal, run `sam init`
+1. Select option **2 - Custom Template Location**
+1. Enter _gh:rts-rob/aws-sam-iterative-replacement-golang_
+1. Provide a project name, e.g., _hello-world_
+1. Change into the created directory
+1. Build with `sam build`
+1. Deploy with `sam deploy --guided`
+    * You will need to provide your existing application root URL as the value for the `PassthroughTarget` parameter, e.g., _https://api.anycompany.com_. Do not include a forward slash `"/"` at the end.
+
+Now you have a sample application with [Amazon API Gateway][api-gateway], [Amazon DynamoDB][dynamodb], and [AWS Lambda][lambda] deployed and running in the region you specified. Your HTTP API will forward all traffic to your `PassthroughTarget` **except for** the routes you explicitly define in your AWS SAM template.
+
+## Next steps
+
+Once deployed, implement your actual route logic one route and method at a time. Shift traffic to one completed route at a time, and monitor for any unexpected behavior.
+
+Once you have iterated through all of your routes, congratulations! You've successfully migrated your monolith. You can shut down the underlying infrastructure, and refocus your ops efforts on improving performance for your customers.
+
+## Contributing
+
+Issue reports and pull requests to help improve these application templates are always welcome. Please see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+
+This project is licensed under the [MIT License][mit-license].
+
+[api-gateway]: https://aws.amazon.com/api-gateway/
+[aws-sam-cli]: https://rbsttr.tv/samcli
+[dynamodb]: https://aws.amazon.com/dynamodb/
+[go]: https://golang.org
+[http-api]: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html
+[lambda]: https://aws.amazon.com/lambda/
+[mit-license]: https://choosealicense.com/licenses/mit/

--- a/none/cookiecutter-iterative-replacement-no-runtime/cookiecutter.json
+++ b/none/cookiecutter-iterative-replacement-no-runtime/cookiecutter.json
@@ -1,0 +1,3 @@
+{
+    "project_name": "Name of the project"
+}

--- a/none/cookiecutter-iterative-replacement-no-runtime/requirements-dev.txt
+++ b/none/cookiecutter-iterative-replacement-no-runtime/requirements-dev.txt
@@ -1,0 +1,4 @@
+cookiecutter==1.6.0
+flake8==3.5.0
+pytest==3.3.2
+pytest-cookies==0.3.0

--- a/none/cookiecutter-iterative-replacement-no-runtime/tests/test_bake_project.py
+++ b/none/cookiecutter-iterative-replacement-no-runtime/tests/test_bake_project.py
@@ -1,0 +1,79 @@
+from contextlib import contextmanager
+
+import os
+import subprocess
+
+
+@contextmanager
+def inside_dir(dirpath):
+    """
+    Execute code from inside the given directory
+    :param dirpath: String, path of the directory the command is being run.
+    """
+    old_path = os.getcwd()
+    try:
+        os.chdir(dirpath)
+        yield
+    finally:
+        os.chdir(old_path)
+
+
+def test_project_tree(cookies):
+    result = cookies.bake(extra_context={'project_name': 'test_project'})
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.project.basename == 'test_project'
+
+    assert result.project.isdir()
+    assert result.project.join('README.md').isfile()
+    assert result.project.join('template.yaml').isfile()
+    assert result.project.join('hello-world').isdir()
+    assert result.project.join('hello-world', 'main.go').isfile()
+    assert result.project.join('hello-world', 'main_test.go').isfile()
+
+
+def test_app_content(cookies):
+    result = cookies.bake(extra_context={'project_name': 'test_project'})
+    app_file = result.project.join('hello-world', 'main.go')
+    app_content = app_file.readlines()
+    app_content = ''.join(app_content)
+
+    contents = (
+        "github.com/aws/aws-lambda-go/events",
+        "resp, err := http.Get(DefaultHTTPGetAddress)",
+        "lambda.Start(handler)"
+    )
+
+    for content in contents:
+        assert content in app_content
+
+
+def test_app_test_content(cookies):
+    result = cookies.bake(extra_context={'project_name': 'test_project'})
+    app_file = result.project.join('hello-world', 'main_test.go')
+    app_content = app_file.readlines()
+    app_content = ''.join(app_content)
+
+    contents = (
+        "DefaultHTTPGetAddress = \"http://127.0.0.1:12345\"",
+        "DefaultHTTPGetAddress = ts.URL",
+        "Successful Request"
+    )
+
+    for content in contents:
+        assert content in app_content
+
+
+def test_app_template_content(cookies):
+    result = cookies.bake(extra_context={'project_name': 'test_project'})
+    app_file = result.project.join('template.yaml')
+    app_content = app_file.readlines()
+    app_content = ''.join(app_content)
+
+    contents = (
+        "Runtime: go1.x",
+        "HelloWorldFunction",
+    )
+
+    for content in contents:
+        assert content in app_content

--- a/none/cookiecutter-iterative-replacement-no-runtime/{{cookiecutter.project_name}}/.gitignore
+++ b/none/cookiecutter-iterative-replacement-no-runtime/{{cookiecutter.project_name}}/.gitignore
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Goland files
+.idea/
+
+# AWS SAM CLI build folder
+.aws-sam/
+
+# AWS SAM CLI guided deploy settings
+samconfig.toml
+
+# macOS files
+.DS_Store

--- a/none/cookiecutter-iterative-replacement-no-runtime/{{cookiecutter.project_name}}/Makefile
+++ b/none/cookiecutter-iterative-replacement-no-runtime/{{cookiecutter.project_name}}/Makefile
@@ -1,0 +1,7 @@
+.PHONY: build test
+
+build:
+	sam build
+
+test:
+	go test -v ./...

--- a/none/cookiecutter-iterative-replacement-no-runtime/{{cookiecutter.project_name}}/README.md
+++ b/none/cookiecutter-iterative-replacement-no-runtime/{{cookiecutter.project_name}}/README.md
@@ -1,0 +1,140 @@
+# {{ cookiecutter.project_name }}
+
+This is a sample template for {{ cookiecutter.project_name }} - Below is a brief explanation of what we have generated for you:
+
+```bash
+.
+├── Makefile                    <-- Make to automate build
+├── README.md                   <-- This instructions file
+├── hello-world                 <-- Source code for a lambda function
+│   ├── main.go                 <-- Lambda function code
+│   └── main_test.go            <-- Unit tests
+└── template.yaml
+```
+
+## Requirements
+
+* AWS CLI already configured with Administrator permission
+* [Docker installed](https://www.docker.com/community-edition)
+* [Golang](https://golang.org)
+* SAM CLI - [Install the SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
+
+## Setup process
+
+### Installing dependencies & building the target 
+
+In this example we use the built-in `sam build` to automatically download all the dependencies and package our build target.   
+Read more about [SAM Build here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-build.html) 
+
+The `sam build` command is wrapped inside of the `Makefile`. To execute this simply run
+ 
+```shell
+make
+```
+
+### Local development
+
+**Invoking function locally through local API Gateway**
+
+```bash
+sam local start-api
+```
+
+If the previous command ran successfully you should now be able to hit the following local endpoint to invoke your function `http://localhost:3000/hello`
+
+**SAM CLI** is used to emulate both Lambda and API Gateway locally and uses our `template.yaml` to understand how to bootstrap this environment (runtime, where the source code is, etc.) - The following excerpt is what the CLI will read in order to initialize an API and its routes:
+
+```yaml
+...
+Events:
+    HelloWorld:
+        Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+        Properties:
+            Path: /hello
+            Method: get
+```
+
+## Packaging and deployment
+
+AWS Lambda Golang runtime requires a flat folder with the executable generated on build step. SAM will use `CodeUri` property to know where to look up for the application:
+
+```yaml
+...
+    FirstFunction:
+        Type: AWS::Serverless::Function
+        Properties:
+            CodeUri: hello_world/
+            ...
+```
+
+To deploy your application for the first time, run the following in your shell:
+
+```bash
+sam deploy --guided
+```
+
+The command will package and deploy your application to AWS, with a series of prompts:
+
+* **Stack Name**: The name of the stack to deploy to CloudFormation. This should be unique to your account and region, and a good starting point would be something matching your project name.
+* **AWS Region**: The AWS region you want to deploy your app to.
+* **Confirm changes before deploy**: If set to yes, any change sets will be shown to you before execution for manual review. If set to no, the AWS SAM CLI will automatically deploy application changes.
+* **Allow SAM CLI IAM role creation**: Many AWS SAM templates, including this example, create AWS IAM roles required for the AWS Lambda function(s) included to access AWS services. By default, these are scoped down to minimum required permissions. To deploy an AWS CloudFormation stack which creates or modified IAM roles, the `CAPABILITY_IAM` value for `capabilities` must be provided. If permission isn't provided through this prompt, to deploy this example you must explicitly pass `--capabilities CAPABILITY_IAM` to the `sam deploy` command.
+* **Save arguments to samconfig.toml**: If set to yes, your choices will be saved to a configuration file inside the project, so that in the future you can just re-run `sam deploy` without parameters to deploy changes to your application.
+
+You can find your API Gateway Endpoint URL in the output values displayed after deployment.
+
+### Testing
+
+We use `testing` package that is built-in in Golang and you can simply run the following command to run our tests:
+
+```shell
+go test -v ./hello-world/
+```
+# Appendix
+
+### Golang installation
+
+Please ensure Go 1.x (where 'x' is the latest version) is installed as per the instructions on the official golang website: https://golang.org/doc/install
+
+A quickstart way would be to use Homebrew, chocolatey or your linux package manager.
+
+#### Homebrew (Mac)
+
+Issue the following command from the terminal:
+
+```shell
+brew install golang
+```
+
+If it's already installed, run the following command to ensure it's the latest version:
+
+```shell
+brew update
+brew upgrade golang
+```
+
+#### Chocolatey (Windows)
+
+Issue the following command from the powershell:
+
+```shell
+choco install golang
+```
+
+If it's already installed, run the following command to ensure it's the latest version:
+
+```shell
+choco upgrade golang
+```
+
+## Bringing to the next level
+
+Here are a few ideas that you can use to get more acquainted as to how this overall process works:
+
+* Create an additional API resource (e.g. /hello/{proxy+}) and return the name requested through this new path
+* Update unit test to capture that
+* Package & Deploy
+
+Next, you can use the following resources to know more about beyond hello world samples and how others structure their Serverless applications:
+
+* [AWS Serverless Application Repository](https://aws.amazon.com/serverless/serverlessrepo/)

--- a/none/cookiecutter-iterative-replacement-no-runtime/{{cookiecutter.project_name}}/api-definition.yaml
+++ b/none/cookiecutter-iterative-replacement-no-runtime/{{cookiecutter.project_name}}/api-definition.yaml
@@ -1,0 +1,33 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+openapi: "3.0.1"
+info:
+  title: "Mainframe to serverless migration"
+  version: "0.1.0"
+
+paths:
+  /{proxy+}:
+    x-amazon-apigateway-any-method:
+      responses:
+        default:
+          description: "Default response for ANY /"
+      x-amazon-apigateway-integration:
+        payloadFormatVersion: "1.0"
+        type: "http_proxy"
+        httpMethod: "ANY"
+        uri: {"Fn::Sub":"${PassthroughTarget}/{proxy}"}
+        connectionType: "INTERNET"

--- a/none/cookiecutter-iterative-replacement-no-runtime/{{cookiecutter.project_name}}/template.yaml
+++ b/none/cookiecutter-iterative-replacement-no-runtime/{{cookiecutter.project_name}}/template.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  {{ cookiecutter.project_name }}
+  
+  AWS SAM Template for {{ cookiecutter.project_name }}
+
+Parameters:
+  PassthroughTarget:
+    Type: String
+    Description: The protocol and hostname for the passthrough target. Do not include a trailing forward-slash. For example, https://github.com
+
+Resources:
+  PassthroughAPI:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      DefinitionBody:
+        'Fn::Transform':
+          Name: 'AWS::Include'
+          Parameters:
+            Location: api-definition.yaml
+      AccessLogSettings:
+        DestinationArn: !GetAtt PassthroughLogs.Arn
+        Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","routeKey":"$context.routeKey", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength", "integrationError:"$context.integrationErrorMessage" }'
+        
+  PassthroughLogs:
+    Type: AWS::Logs::LogGroup
+
+Outputs:
+  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
+  # Find out more about other implicit resources you can reference within SAM
+  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
+  APIRoot:
+    Description: "API Gateway root URL for migration"
+    Value: !Sub "https://${PassthroughAPI}.execute-api.${AWS::Region}.amazonaws.com"

--- a/none/cookiecutter-step-functions-only/.gitignore
+++ b/none/cookiecutter-step-functions-only/.gitignore
@@ -1,0 +1,168 @@
+
+# Created by https://www.gitignore.io/api/osx,linux,python,windows
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### OSX ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule.*
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+# End of https://www.gitignore.io/api/osx,linux,python,windows

--- a/none/cookiecutter-step-functions-only/README.md
+++ b/none/cookiecutter-step-functions-only/README.md
@@ -1,0 +1,20 @@
+# Cookiecutter No Runtime "Step Functions Only" Quick Start Application
+
+A cookiecutter template to create a basic Quick Start Application using [Serverless Application Model (SAM)](https://github.com/awslabs/serverless-application-model).
+
+## Requirements
+
+* [AWS SAM CLI](https://github.com/awslabs/aws-sam-cli)
+
+## Usage
+
+Generate a boilerplate template in your current project directory using the following syntax:
+
+* **None**: `sam init --runtime none --application-template step-functions-only --name sam-app`
+
+> **NOTE**: ``--name`` allows you to specify a different project folder name
+
+# Credits
+
+* This project has been generated with [Cookiecutter](https://github.com/audreyr/cookiecutter)
+

--- a/none/cookiecutter-step-functions-only/cookiecutter.json
+++ b/none/cookiecutter-step-functions-only/cookiecutter.json
@@ -1,0 +1,4 @@
+{
+    "project_name": "Name of the project",
+    "runtime": "none"
+}

--- a/none/cookiecutter-step-functions-only/setup.cfg
+++ b/none/cookiecutter-step-functions-only/setup.cfg
@@ -1,0 +1,2 @@
+[install]
+prefix= 

--- a/none/cookiecutter-step-functions-only/{{cookiecutter.project_name}}/README.md
+++ b/none/cookiecutter-step-functions-only/{{cookiecutter.project_name}}/README.md
@@ -1,0 +1,130 @@
+# {{cookiecutter.project_name}}
+
+This project contains source code and supporting files for a serverless application that you can deploy with the AWS Serverless Application Model (AWS SAM) command line interface (CLI). It includes the following files and folders:
+
+- `template.yml` - A template that defines the application's AWS resources.
+
+Resources for this project are defined in the `template.yml` file in this project. You can update the template to add AWS resources through the same deployment process that updates your application code.
+
+If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.  
+The AWS Toolkit is an open-source plugin for popular IDEs that uses the AWS SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds step-through debugging for Lambda function code. 
+
+To get started, see the following:
+
+* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
+* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
+* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
+
+## Deploy the sample application
+
+The AWS SAM CLI is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
+
+To use the AWS SAM CLI, you need the following tools:
+
+* AWS SAM CLI - [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
+* Node.js - [Install Node.js 12](https://nodejs.org/en/), including the npm package management tool.
+* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community).
+
+To build and deploy your application for the first time, run the following in your shell:
+
+```bash
+sam build
+sam deploy --guided
+```
+
+The first command will build the source of your application. The second command will package and deploy your application to AWS, with a series of prompts:
+
+* **Stack Name**: The name of the stack to deploy to CloudFormation. This should be unique to your account and region, and a good starting point would be something matching your project name.
+* **AWS Region**: The AWS region you want to deploy your app to.
+* **Confirm changes before deploy**: If set to yes, any change sets will be shown to you before execution for manual review. If set to no, the AWS SAM CLI will automatically deploy application changes.
+* **Allow SAM CLI IAM role creation**: Many AWS SAM templates, including this example, create AWS IAM roles required for the AWS Lambda function(s) included to access AWS services. By default, these are scoped down to minimum required permissions. To deploy an AWS CloudFormation stack which creates or modified IAM roles, the `CAPABILITY_IAM` value for `capabilities` must be provided. If permission isn't provided through this prompt, to deploy this example you must explicitly pass `--capabilities CAPABILITY_IAM` to the `sam deploy` command.
+* **Save arguments to samconfig.toml**: If set to yes, your choices will be saved to a configuration file inside the project, so that in the future you can just re-run `sam deploy` without parameters to deploy changes to your application.
+
+## Use the AWS SAM CLI to build and test locally
+
+Build your application by using the `sam build` command.
+
+```bash
+my-application$ sam build
+```
+
+The AWS SAM CLI installs dependencies that are defined in `package.json`, creates a deployment package, and saves it in the `.aws-sam/build` folder.
+
+Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
+
+Run functions locally and invoke them with the `sam local invoke` command.
+
+```bash
+my-application$ sam local invoke helloFromLambdaFunction --no-event
+```
+
+## Add a resource to your application
+
+The application template uses AWS SAM to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources, such as functions, triggers, and APIs. For resources that aren't included in the [AWS SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use the standard [AWS CloudFormation resource types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
+
+Update `template.yml` to add a dead-letter queue to your application. In the **Resources** section, add a resource named **MyQueue** with the type **AWS::SQS::Queue**. Then add a property to the **AWS::Serverless::Function** resource named **DeadLetterQueue** that targets the queue's Amazon Resource Name (ARN), and a policy that grants the function permission to access the queue.
+
+```
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+  helloFromLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/hello-from-lambda.helloFromLambdaHandler
+      Runtime: nodejs12.x
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt MyQueue.Arn
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt MyQueue.QueueName
+```
+
+The dead-letter queue is a location for Lambda to send events that could not be processed. It's only used if you invoke your function asynchronously, but it's useful here to show how you can modify your application's resources and function configuration.
+
+Deploy the updated application.
+
+```bash
+my-application$ sam deploy
+```
+
+Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page of the Lambda console, and choose your application. When the deployment completes, view the application resources on the **Overview** tab to see the new resource. Then, choose the function to see the updated configuration that specifies the dead-letter queue.
+
+## Fetch, tail, and filter Lambda function logs
+
+To simplify troubleshooting, the AWS SAM CLI has a command called `sam logs`. `sam logs` lets you fetch logs that are generated by your Lambda function from the command line. In addition to printing the logs on the terminal, this command has several nifty features to help you quickly find the bug.
+
+**NOTE:** This command works for all Lambda functions, not just the ones you deploy using AWS SAM.
+
+```bash
+my-application$ sam logs -n helloFromLambdaFunction --stack-name sam-app --tail
+```
+
+**NOTE:** This uses the logical name of the function within the stack. This is the correct name to use when searching logs inside an AWS Lambda function within a CloudFormation stack, even if the deployed function name varies due to CloudFormation's unique resource name generation.
+
+You can find more information and examples about filtering Lambda function logs in the [AWS SAM CLI documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
+
+## Unit tests
+
+Tests are defined in the `__tests__` folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
+
+```bash
+my-application$ npm install
+my-application$ npm run test
+```
+
+## Cleanup
+
+To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
+
+```bash
+aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+```
+
+## Resources
+
+For an introduction to the AWS SAM specification, the AWS SAM CLI, and serverless application concepts, see the [AWS SAM Developer Guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html).
+
+Next, you can use the AWS Serverless Application Repository to deploy ready-to-use apps that go beyond Hello World samples and learn how authors developed their applications. For more information, see the [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/) and the [AWS Serverless Application Repository Developer Guide](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/what-is-serverlessrepo.html).

--- a/none/cookiecutter-step-functions-only/{{cookiecutter.project_name}}/buildspec.yml
+++ b/none/cookiecutter-step-functions-only/{{cookiecutter.project_name}}/buildspec.yml
@@ -1,0 +1,11 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      # Use AWS SAM to package the application by using AWS CloudFormation
+      - aws cloudformation package --template template.yml --s3-bucket $S3_BUCKET --output-template template-export.yml
+artifacts:
+  type: zip
+  files:
+    - template-export.yml

--- a/none/cookiecutter-step-functions-only/{{cookiecutter.project_name}}/statemachine/hello-world.asl.json
+++ b/none/cookiecutter-step-functions-only/{{cookiecutter.project_name}}/statemachine/hello-world.asl.json
@@ -1,0 +1,27 @@
+{
+  "Comment": "A Hello World example demonstrating various state types of the Amazon States Language",
+  "StartAt": "First State",
+  "States": {
+      "First State": {
+          "Comment": "A Pass state passes its input to its output, without performing work. Pass states are useful when constructing and debugging state machines.",
+          "Type": "Pass",
+          "Parameters": {
+            "Message": "Hello, world!"
+          },
+          "Next": "Write to DynamoDB"
+      },
+      "Write to DynamoDB": {
+        "Type": "Task",
+        "Resource": "arn:aws:states:::dynamodb:putItem",
+        "Parameters": {
+          "TableName": "${DynamoDBTableName}",
+          "Item": {
+            "id.$": "$$.Execution.Id",
+            "message.$": "$.Message"
+          }
+        },
+        "ResultPath": "$.DynamoDB",
+        "End": true
+      }
+  }
+}

--- a/none/cookiecutter-step-functions-only/{{cookiecutter.project_name}}/template.yml
+++ b/none/cookiecutter-step-functions-only/{{cookiecutter.project_name}}/template.yml
@@ -1,0 +1,60 @@
+# This is the SAM template that represents the architecture of your serverless application
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-template-basics.html
+
+# The AWSTemplateFormatVersion identifies the capabilities of the template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  {{cookiecutter.project_name}}
+
+# Transform section specifies one or more macros that AWS CloudFormation uses to process your template
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-section-structure.html
+Transform:
+- AWS::Serverless-2016-10-31
+
+# Resources declares the AWS resources that you want to include in the stack
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
+Resources:
+  # Simple syntax to create a DynamoDB table with a single attribute primary key, more in
+  # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlesssimpletable
+  HelloTable:
+    Type: AWS::Serverless::SimpleTable
+  
+  # A simple Amazon Cloudwatch Logs log group
+  # https://docs.aws.amazon.com/step-functions/latest/dg/cw-logs.html
+  HelloLogs:
+    Type: AWS::Logs::LogGroup
+
+  # An AWS Step Functions Express Workflow invoked via API Gateway that stores its execution ID in a DynamoDB table
+  # https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
+  HelloStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: statemachine/hello-world.asl.json
+      DefinitionSubstitutions:
+        DynamoDBTableName: !Ref HelloTable
+      Events:
+        HttpRequest:
+          Type: Api
+          Properties:
+            Method: POST
+            Path: /hello
+      Logging:
+        Destinations:
+          - CloudWatchLogsLogGroup: 
+              LogGroupArn: !GetAtt HelloLogs.Arn
+        IncludeExecutionData: true
+        Level: ALL
+      Policies:
+        - CloudWatchLogsFullAccess
+        - DynamoDBWritePolicy: 
+            TableName: !Ref HelloTable
+      Type: EXPRESS
+
+Outputs:
+  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
+  # Find out more about other implicit resources you can reference within SAM
+  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
+  WebEndpoint:
+    Description: "API Gateway endpoint URL for Prod stage"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This pull request adds a template for the "iterative replacement" pattern of migrating a monolith to a serverless architecture. This pattern places an API Gateway HTTP API in front of your existing monolith, then allows you to rewrite one route at a time. This template **does not include** any sample routes, but rather creates a true proxy pass-through as a getting-started point.

This PR depends on #48 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
