### PR TITLE
Upgrade template dependencies

### DIFF
--- a/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.3.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
   

--- a/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.3.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
   

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockBuyer/StockBuyer.csproj
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockBuyer/StockBuyer.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
   </ItemGroup>
 
 </Project>

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockChecker/StockChecker.csproj
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockChecker/StockChecker.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
   </ItemGroup>
 
 </Project>

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockSeller/StockSeller.csproj
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockSeller/StockSeller.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
   </ItemGroup>
 
 </Project>

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockBuyer.Test/StockBuyer.Tests.csproj
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockBuyer.Test/StockBuyer.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockChecker.Test/StockChecker.Tests.csproj
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockChecker.Test/StockChecker.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockSeller.Test/StockSeller.Tests.csproj
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockSeller.Test/StockSeller.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.3.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 </Project>

--- a/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -6,9 +6,9 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.3.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 </Project>

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -6,9 +6,9 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockBuyer/StockBuyer.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockBuyer/StockBuyer.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
   </ItemGroup>
 </Project>
 

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockChecker/StockChecker.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockChecker/StockChecker.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
   </ItemGroup>
 </Project>
 

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockSeller/StockSeller.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockSeller/StockSeller.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
   </ItemGroup>
 </Project>
 

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockBuyer.Test/StockBuyer.Tests.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockBuyer.Test/StockBuyer.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockChecker.Test/StockChecker.Tests.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockChecker.Test/StockChecker.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockSeller.Test/StockSeller.Tests.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockSeller.Test/StockSeller.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/java11-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java11-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     implementation 'com.amazonaws:aws-lambda-java-events:3.1.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/java11-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java11-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-lambda-java-events</artifactId>
-          <version>3.1.0</version>
+          <version>3.6.0</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -35,7 +35,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java11/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java11/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,9 +7,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.10.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java11/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java11/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -26,17 +26,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
     </dependencies>
 
@@ -45,7 +45,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
+++ b/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
@@ -7,9 +7,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.10.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
+++ b/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -26,17 +26,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
     </dependencies>
 
@@ -45,7 +45,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java11/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java11/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
-    implementation 'com.amazonaws:aws-lambda-java-events:3.1.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-events:3.6.0'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java11/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java11/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-lambda-java-events</artifactId>
-          <version>3.1.0</version>
+          <version>3.6.0</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -35,7 +35,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java11/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
+++ b/java11/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java11/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
+++ b/java11/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java11/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
+++ b/java11/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java11/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
+++ b/java11/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -30,7 +30,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java11/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
+++ b/java11/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -30,7 +30,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java11/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
+++ b/java11/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -30,7 +30,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     implementation 'com.amazonaws:aws-lambda-java-events:3.1.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-lambda-java-events</artifactId>
-          <version>3.1.0</version>
+          <version>3.6.0</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -35,7 +35,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8.al2-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8.al2-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     implementation 'com.amazonaws:aws-lambda-java-events:3.1.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/java8.al2-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8.al2-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-lambda-java-events</artifactId>
-          <version>3.1.0</version>
+          <version>3.6.0</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -35,7 +35,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,9 +7,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.10.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -26,17 +26,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
     </dependencies>
 
@@ -45,7 +45,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
@@ -7,9 +7,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.10.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -26,17 +26,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
     </dependencies>
 
@@ -45,7 +45,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8.al2/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8.al2/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java8.al2/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8.al2/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -30,7 +30,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
+++ b/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
+++ b/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
+++ b/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
+++ b/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -30,7 +30,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
+++ b/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -30,7 +30,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
+++ b/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -30,7 +30,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,9 +7,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.10.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java8/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -26,17 +26,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
     </dependencies>
 
@@ -45,7 +45,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
+++ b/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
@@ -7,9 +7,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.10.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
+++ b/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -26,17 +26,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
     </dependencies>
 
@@ -45,7 +45,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
-    implementation 'com.amazonaws:aws-lambda-java-events:3.1.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-events:3.6.0'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java8/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-lambda-java-events</artifactId>
-          <version>3.1.0</version>
+          <version>3.6.0</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -35,7 +35,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
+++ b/java8/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java8/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
+++ b/java8/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java8/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
+++ b/java8/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/java8/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
+++ b/java8/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -30,7 +30,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
+++ b/java8/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -30,7 +30,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/java8/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
+++ b/java8/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -30,7 +30,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.4</version>
           <configuration>
           </configuration>
           <executions>

--- a/nodejs10.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/{{cookiecutter.project_name}}/hello-world/package.json
+++ b/nodejs10.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/{{cookiecutter.project_name}}/hello-world/package.json
@@ -7,13 +7,13 @@
   "author": "SAM CLI",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.18.0"
+    "axios": "^0.21.0"
   },
   "scripts": {
     "test": "mocha tests/unit/"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^8.2.1"
   }
 }

--- a/nodejs10.x/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
+++ b/nodejs10.x/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
@@ -7,13 +7,13 @@
   "author": "SAM CLI",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.18.0"
+    "axios": "^0.21.0"
   },
   "scripts": {
     "test": "mocha tests/unit/"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^8.2.1"
   }
 }

--- a/nodejs10.x/cookiecutter-aws-sam-step-functions-sample-app/{{cookiecutter.project_name}}/functions/stock-buyer/package.json
+++ b/nodejs10.x/cookiecutter-aws-sam-step-functions-sample-app/{{cookiecutter.project_name}}/functions/stock-buyer/package.json
@@ -12,6 +12,6 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^8.2.1"
   }
 }

--- a/nodejs10.x/cookiecutter-aws-sam-step-functions-sample-app/{{cookiecutter.project_name}}/functions/stock-checker/package.json
+++ b/nodejs10.x/cookiecutter-aws-sam-step-functions-sample-app/{{cookiecutter.project_name}}/functions/stock-checker/package.json
@@ -12,6 +12,6 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^8.2.1"
   }
 }

--- a/nodejs10.x/cookiecutter-aws-sam-step-functions-sample-app/{{cookiecutter.project_name}}/functions/stock-seller/package.json
+++ b/nodejs10.x/cookiecutter-aws-sam-step-functions-sample-app/{{cookiecutter.project_name}}/functions/stock-seller/package.json
@@ -12,6 +12,6 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^8.2.1"
   }
 }

--- a/nodejs10.x/cookiecutter-quick-start-cloudwatch-events/{{cookiecutter.project_name}}/package.json
+++ b/nodejs10.x/cookiecutter-quick-start-cloudwatch-events/{{cookiecutter.project_name}}/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "dependencies": {},
     "devDependencies": {
-        "jest": "^24.7.1"
+        "jest": "^26.6.3"
     },
     "scripts": {
         "test": "jest"

--- a/nodejs10.x/cookiecutter-quick-start-from-scratch/{{cookiecutter.project_name}}/package.json
+++ b/nodejs10.x/cookiecutter-quick-start-from-scratch/{{cookiecutter.project_name}}/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "dependencies": {},
     "devDependencies": {
-        "jest": "^24.7.1"
+        "jest": "^26.6.3"
     },
     "scripts": {
         "test": "jest"

--- a/nodejs10.x/cookiecutter-quick-start-s3/{{cookiecutter.project_name}}/package.json
+++ b/nodejs10.x/cookiecutter-quick-start-s3/{{cookiecutter.project_name}}/package.json
@@ -4,11 +4,11 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "aws-sdk": "^2.442.0"
+    "aws-sdk": "^2.799.0"
   },
   "devDependencies": {
-    "jest": "^24.7.1",
-    "aws-sdk-mock": "^4.5.0"
+    "jest": "^26.6.3",
+    "aws-sdk-mock": "^5.1.0"
   },
   "scripts": {
     "test": "jest"

--- a/nodejs10.x/cookiecutter-quick-start-sns/{{cookiecutter.project_name}}/package.json
+++ b/nodejs10.x/cookiecutter-quick-start-sns/{{cookiecutter.project_name}}/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "dependencies": {},
     "devDependencies": {
-        "jest": "^24.7.1"
+        "jest": "^26.6.3"
     },
     "scripts": {
         "test": "jest"

--- a/nodejs10.x/cookiecutter-quick-start-sqs/{{cookiecutter.project_name}}/package.json
+++ b/nodejs10.x/cookiecutter-quick-start-sqs/{{cookiecutter.project_name}}/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "dependencies": {},
     "devDependencies": {
-        "jest": "^24.7.1"
+        "jest": "^26.6.3"
     },
     "scripts": {
         "test": "jest"

--- a/nodejs10.x/cookiecutter-quick-start-web/{{cookiecutter.project_name}}/package.json
+++ b/nodejs10.x/cookiecutter-quick-start-web/{{cookiecutter.project_name}}/package.json
@@ -4,10 +4,10 @@
     "version": "0.0.1",
     "private": true,
     "dependencies": {
-        "aws-sdk": "^2.437.0"
+        "aws-sdk": "^2.799.0"
     },
     "devDependencies": {
-        "jest": "^24.7.1"
+        "jest": "^26.6.3"
     },
     "scripts": {
         "test": "jest"

--- a/nodejs12.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/{{cookiecutter.project_name}}/hello-world/package.json
+++ b/nodejs12.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/{{cookiecutter.project_name}}/hello-world/package.json
@@ -7,13 +7,13 @@
   "author": "SAM CLI",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.18.0"
+    "axios": "^0.21.0"
   },
   "scripts": {
     "test": "mocha tests/unit/"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^8.2.1"
   }
 }

--- a/nodejs12.x/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
+++ b/nodejs12.x/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
@@ -7,13 +7,13 @@
   "author": "SAM CLI",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.18.0"
+    "axios": "^0.21.0"
   },
   "scripts": {
     "test": "mocha tests/unit/"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^8.2.1"
   }
 }

--- a/nodejs12.x/cookiecutter-aws-sam-step-functions-sample-app/{{cookiecutter.project_name}}/functions/stock-buyer/package.json
+++ b/nodejs12.x/cookiecutter-aws-sam-step-functions-sample-app/{{cookiecutter.project_name}}/functions/stock-buyer/package.json
@@ -12,6 +12,6 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^8.2.1"
   }
 }

--- a/nodejs12.x/cookiecutter-aws-sam-step-functions-sample-app/{{cookiecutter.project_name}}/functions/stock-checker/package.json
+++ b/nodejs12.x/cookiecutter-aws-sam-step-functions-sample-app/{{cookiecutter.project_name}}/functions/stock-checker/package.json
@@ -12,6 +12,6 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^8.2.1"
   }
 }

--- a/nodejs12.x/cookiecutter-aws-sam-step-functions-sample-app/{{cookiecutter.project_name}}/functions/stock-seller/package.json
+++ b/nodejs12.x/cookiecutter-aws-sam-step-functions-sample-app/{{cookiecutter.project_name}}/functions/stock-seller/package.json
@@ -12,6 +12,6 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.1.4"
+    "mocha": "^8.2.1"
   }
 }

--- a/nodejs12.x/cookiecutter-quick-start-cloudwatch-events/{{cookiecutter.project_name}}/package.json
+++ b/nodejs12.x/cookiecutter-quick-start-cloudwatch-events/{{cookiecutter.project_name}}/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "dependencies": {},
     "devDependencies": {
-        "jest": "^24.7.1"
+        "jest": "^26.6.3"
     },
     "scripts": {
         "test": "jest"

--- a/nodejs12.x/cookiecutter-quick-start-from-scratch/{{cookiecutter.project_name}}/package.json
+++ b/nodejs12.x/cookiecutter-quick-start-from-scratch/{{cookiecutter.project_name}}/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "dependencies": {},
     "devDependencies": {
-        "jest": "^24.7.1"
+        "jest": "^26.6.3"
     },
     "scripts": {
         "test": "jest"

--- a/nodejs12.x/cookiecutter-quick-start-s3/{{cookiecutter.project_name}}/package.json
+++ b/nodejs12.x/cookiecutter-quick-start-s3/{{cookiecutter.project_name}}/package.json
@@ -4,11 +4,11 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "aws-sdk": "^2.442.0"
+    "aws-sdk": "^2.799.0"
   },
   "devDependencies": {
-    "jest": "^24.7.1",
-    "aws-sdk-mock": "^4.5.0"
+    "jest": "^26.6.3",
+    "aws-sdk-mock": "^5.1.0"
   },
   "scripts": {
     "test": "jest"

--- a/nodejs12.x/cookiecutter-quick-start-sns/{{cookiecutter.project_name}}/package.json
+++ b/nodejs12.x/cookiecutter-quick-start-sns/{{cookiecutter.project_name}}/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "dependencies": {},
     "devDependencies": {
-        "jest": "^24.7.1"
+        "jest": "^26.6.3"
     },
     "scripts": {
         "test": "jest"

--- a/nodejs12.x/cookiecutter-quick-start-sqs/{{cookiecutter.project_name}}/package.json
+++ b/nodejs12.x/cookiecutter-quick-start-sqs/{{cookiecutter.project_name}}/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "dependencies": {},
     "devDependencies": {
-        "jest": "^24.7.1"
+        "jest": "^26.6.3"
     },
     "scripts": {
         "test": "jest"

--- a/nodejs12.x/cookiecutter-quick-start-web/{{cookiecutter.project_name}}/package.json
+++ b/nodejs12.x/cookiecutter-quick-start-web/{{cookiecutter.project_name}}/package.json
@@ -4,10 +4,10 @@
     "version": "0.0.1",
     "private": true,
     "dependencies": {
-        "aws-sdk": "^2.437.0"
+        "aws-sdk": "^2.799.0"
     },
     "devDependencies": {
-        "jest": "^24.7.1"
+        "jest": "^26.6.3"
     },
     "scripts": {
         "test": "jest"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

update template dependencies to the latest versions.

Right now `tests/integration/build_invoke/build_invoke_base.py` failed because of docker request limit.

I ran it locally and they all passed:

```sh
$ pytest -vvv tests/integration/build_invoke/test_build_invoke.py -n 8

...
[gw7] [ 98%] PASSED tests/integration/build_invoke/test_build_invoke.py::BuildInvoke_java8_cookiecutter_aws_sam_step_functions_sample_app_maven::test_buld_and_invoke <- tests/integration/build_invoke/build_invoke_base.py 
tests/integration/build_invoke/test_build_invoke.py::BuildInvoke_java8_al2_cookiecutter_aws_sam_step_functions_sample_app_maven::test_buld_and_invoke <- tests/integration/build_invoke/build_invoke_base.py 
[gw7] [100%] PASSED tests/integration/build_invoke/test_build_invoke.py::BuildInvoke_java8_al2_cookiecutter_aws_sam_step_functions_sample_app_maven::test_buld_and_invoke <- tests/integration/build_invoke/build_invoke_base.py 

================================================================================================================================== 50 passed, 9 skipped, 6 rerun in 1008.59s (0:16:48) ===================================================================================================================================
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
