### PR TITLE
ci: Fix Python2.7 template unit test fails in CI due to pip dropping support

### DIFF
--- a/buildspecs/buildspec-unittest-python2.7.yml
+++ b/buildspecs/buildspec-unittest-python2.7.yml
@@ -14,7 +14,7 @@ phases:
       - make install
       - cd ..
       # install pip
-      - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+      - curl https://bootstrap.pypa.io/2.7/get-pip.py -o get-pip.py
       - python2.7 get-pip.py
       # install requirements
       - python3 -m pip install --upgrade pip aws-sam-cli


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Same as #82, pip drops python 2 support, we need to install an old version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
