### PR TITLE
Changed dotnetcore3.1 HelloWorld samples to 256MB

### DIFF
--- a/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -13,6 +13,7 @@ Resources:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
       PackageType: Image
+      MemorySize: 256
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
@@ -15,6 +15,7 @@ Resources:
       CodeUri: ./src/HelloWorld/
       Handler: HelloWorld::HelloWorld.Function::FunctionHandler
       Runtime: dotnetcore3.1
+      MemorySize: 256
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
The template.yaml for the dotnetcore3.1 'Hello World' samples don't specify the function memory size, so the default of 128MB applies. However, when making even small changes, I found myself getting errors. It took forever to figure out that this was because the memory size was too small.

This PR adds a line to the template.yaml for the HelloWorld samples (ZIP and container image) to specify the memory size as 256. This resolves the above issue, makes the functions start faster, and also is consistent with the 'aws-lambda-tools-defaults.json' file that is already in each project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
