### PR TITLE
chore: Remove legacy "runtime" key from template cookiecutter

### DIFF
--- a/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/cookiecutter.json
+++ b/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "dotnet5.0"
+    "project_name": "Name of the project"
 }

--- a/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -20,7 +20,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: dotnet5.0-v1
       DockerContext: ./src/HelloWorld
       Dockerfile: Dockerfile
       DockerBuildArgs:

--- a/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/cookiecutter.json
+++ b/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "dotnetcore2.1"
+    "project_name": "Name of the project"
 }

--- a/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    {%- else %}
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    {%- endif %}
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
+++ b/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
@@ -11,11 +11,7 @@
   "profile":"",
   "region" : "",
   "configuration": "Release",
-  {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
-  "framework": "netcoreapp2.0",
-  {%- else %}
   "framework" : "netcoreapp2.1",
-  {%- endif %}
   "function-runtime":"dotnetcore2.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,

--- a/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
+++ b/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
@@ -16,7 +16,7 @@
   {%- else %}
   "framework" : "netcoreapp2.1",
   {%- endif %}
-  "function-runtime":"{{ cookiecutter.runtime }}",
+  "function-runtime":"dotnetcore2.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,
   "function-handler" : "HelloWorld::HelloWorld.Function::FunctionHandler"

--- a/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -20,7 +20,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: dotnetcore2.1-v1
       DockerContext: ./src/HelloWorld
       Dockerfile: Dockerfile
       DockerBuildArgs:

--- a/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/dotnetcore2.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    {%- else %}
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    {%- endif %}
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/cookiecutter.json
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "dotnetcore2.1"
+    "project_name": "Name of the project"
 }

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    {%- else %}
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    {%- endif %}
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
@@ -11,11 +11,7 @@
   "profile":"",
   "region" : "",
   "configuration": "Release",
-  {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
-  "framework": "netcoreapp2.0",
-  {%- else %}
   "framework" : "netcoreapp2.1",
-  {%- endif %}
   "function-runtime":"dotnetcore2.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
@@ -16,7 +16,7 @@
   {%- else %}
   "framework" : "netcoreapp2.1",
   {%- endif %}
-  "function-runtime":"{{ cookiecutter.runtime }}",
+  "function-runtime":"dotnetcore2.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,
   "function-handler" : "HelloWorld::HelloWorld.Function::FunctionHandler"

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
@@ -15,7 +15,7 @@ Resources:
       CodeUri: ./src/HelloWorld/
       Handler: HelloWorld::HelloWorld.Function::FunctionHandler
       {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: dotnetcore2.1
       {%- else %}
       Runtime: dotnetcore2.1
       {%- endif %}

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
@@ -14,11 +14,7 @@ Resources:
     Properties:
       CodeUri: ./src/HelloWorld/
       Handler: HelloWorld::HelloWorld.Function::FunctionHandler
-      {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
       Runtime: dotnetcore2.1
-      {%- else %}
-      Runtime: dotnetcore2.1
-      {%- endif %}
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    {%- else %}
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    {%- endif %}
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/cookiecutter.json
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "dotnetcore2.1"
+    "project_name": "Name of the project"
 }

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockBuyer/aws-lambda-tools-defaults.json
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockBuyer/aws-lambda-tools-defaults.json
@@ -12,7 +12,7 @@
   "region" : "",
   "configuration": "Release",
   "framework" : "netcoreapp2.1",
-  "function-runtime":"{{ cookiecutter.runtime }}",
+  "function-runtime":"dotnetcore2.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,
   "function-handler" : "StockBuyer::StockBuyer.Function::FunctionHandler"

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockChecker/aws-lambda-tools-defaults.json
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockChecker/aws-lambda-tools-defaults.json
@@ -12,7 +12,7 @@
   "region" : "",
   "configuration": "Release",
   "framework" : "netcoreapp2.1",
-  "function-runtime":"{{ cookiecutter.runtime }}",
+  "function-runtime":"dotnetcore2.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,
   "function-handler" : "StockChecker::StockChecker.Function::FunctionHandler"

--- a/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockSeller/aws-lambda-tools-defaults.json
+++ b/dotnetcore2.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockSeller/aws-lambda-tools-defaults.json
@@ -12,7 +12,7 @@
   "region" : "",
   "configuration": "Release",
   "framework" : "netcoreapp2.1",
-  "function-runtime":"{{ cookiecutter.runtime }}",
+  "function-runtime":"dotnetcore2.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,
   "function-handler" : "StockSeller::StockSeller.Function::FunctionHandler"

--- a/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/cookiecutter.json
+++ b/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "dotnetcore3.1"
+    "project_name": "Name of the project"
 }

--- a/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
+++ b/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
@@ -12,7 +12,7 @@
   "region" : "",
   "configuration": "Release",
   "framework" : "netcoreapp3.1",
-  "function-runtime":"{{ cookiecutter.runtime }}",
+  "function-runtime":"dotnetcore3.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,
   "function-handler" : "HelloWorld::HelloWorld.Function::FunctionHandler"

--- a/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -20,7 +20,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: dotnetcore3.1-v1
       DockerContext: ./src/HelloWorld
       Dockerfile: Dockerfile
       DockerBuildArgs:

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/cookiecutter.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "dotnetcore3.1"
+    "project_name": "Name of the project"
 }

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
@@ -12,7 +12,7 @@
   "region" : "",
   "configuration": "Release",
   "framework" : "netcoreapp3.1",
-  "function-runtime":"{{ cookiecutter.runtime }}",
+  "function-runtime":"dotnetcore3.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,
   "function-handler" : "HelloWorld::HelloWorld.Function::FunctionHandler"

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-powershell/cookiecutter.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-powershell/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "dotnetcore3.1"
+    "project_name": "Name of the project"
 }

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/cookiecutter.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "dotnetcore3.1"
+    "project_name": "Name of the project"
 }

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockBuyer/aws-lambda-tools-defaults.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockBuyer/aws-lambda-tools-defaults.json
@@ -12,7 +12,7 @@
   "region" : "",
   "configuration": "Release",
   "framework" : "netcoreapp3.1",
-  "function-runtime":"{{ cookiecutter.runtime }}",
+  "function-runtime":"dotnetcore3.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,
   "function-handler" : "StockBuyer::StockBuyer.Function::FunctionHandler"

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockChecker/aws-lambda-tools-defaults.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockChecker/aws-lambda-tools-defaults.json
@@ -12,7 +12,7 @@
   "region" : "",
   "configuration": "Release",
   "framework" : "netcoreapp3.1",
-  "function-runtime":"{{ cookiecutter.runtime }}",
+  "function-runtime":"dotnetcore3.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,
   "function-handler" : "StockChecker::StockChecker.Function::FunctionHandler"

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockSeller/aws-lambda-tools-defaults.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockSeller/aws-lambda-tools-defaults.json
@@ -12,7 +12,7 @@
   "region" : "",
   "configuration": "Release",
   "framework" : "netcoreapp3.1",
-  "function-runtime":"{{ cookiecutter.runtime }}",
+  "function-runtime":"dotnetcore3.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,
   "function-handler" : "StockSeller::StockSeller.Function::FunctionHandler"

--- a/go1.x-image/cookiecutter-aws-sam-hello-golang-lambda-image/cookiecutter.json
+++ b/go1.x-image/cookiecutter-aws-sam-hello-golang-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "go1.x"
+    "project_name": "Name of the project"
 }

--- a/go1.x-image/cookiecutter-aws-sam-hello-golang-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/go1.x-image/cookiecutter-aws-sam-hello-golang-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -25,7 +25,7 @@ Resources:
         Variables:
           PARAM1: VALUE
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: go1.x-v1
       DockerContext: ./hello-world
       Dockerfile: Dockerfile
 

--- a/go1.x/cookiecutter-aws-sam-hello-golang/cookiecutter.json
+++ b/go1.x/cookiecutter-aws-sam-hello-golang/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "go1.x"
+    "project_name": "Name of the project"
 }

--- a/go1.x/cookiecutter-aws-sam-hello-step-functions-sample-app/cookiecutter.json
+++ b/go1.x/cookiecutter-aws-sam-hello-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "go1.x"
+    "project_name": "Name of the project"
 }

--- a/java11-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/cookiecutter.json
+++ b/java11-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java11"
+    "project_name": "Name of the project"
 }

--- a/java11-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java11-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-gradle-v1
+      DockerTag: java11-gradle-v1
       DockerContext: ./HelloWorldFunction
       Dockerfile: Dockerfile
 

--- a/java11-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/cookiecutter.json
+++ b/java11-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java11"
+    "project_name": "Name of the project"
 }

--- a/java11-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java11-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-maven-v1
+      DockerTag: java11-maven-v1
       DockerContext: ./HelloWorldFunction
       Dockerfile: Dockerfile
 

--- a/java11/cookiecutter-aws-sam-eventbridge-hello-java-gradle/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-eventbridge-hello-java-gradle/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Your EventBridge Starter app",
-    "runtime": "java11"
+    "project_name": "Your EventBridge Starter app"
 }

--- a/java11/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: helloworld.App::handleRequest
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: java11
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/java11/cookiecutter-aws-sam-eventbridge-hello-java-maven/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-eventbridge-hello-java-maven/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Your EventBridge Starter app",
-    "runtime": "java11"
+    "project_name": "Your EventBridge Starter app"
 }

--- a/java11/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: helloworld.App::handleRequest
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: java11
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/cookiecutter.json
@@ -1,6 +1,5 @@
 {
     "project_name": "Your EventBridge Starter app",
-    "runtime": "java11",
     "function_name": "HelloWorldFunction",
     "AWS_Schema_registry": "aws.events",
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",

--- a/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: {{cookiecutter.function_name}}
       Handler: helloworld.App::handleRequest
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: java11
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/cookiecutter.json
@@ -1,6 +1,5 @@
 {
     "project_name": "Your EventBridge Starter app",
-    "runtime": "java11",
     "function_name": "HelloWorldFunction",
     "AWS_Schema_registry": "aws.events",
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",

--- a/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: helloworld.App::handleRequest
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: java11
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/java11/cookiecutter-aws-sam-hello-java-gradle/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-hello-java-gradle/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java11"
+    "project_name": "Name of the project"
 }

--- a/java11/cookiecutter-aws-sam-hello-java-maven/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-hello-java-maven/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java11"
+    "project_name": "Name of the project"
 }

--- a/java11/cookiecutter-aws-sam-step-functions-sample-app-gradle/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-step-functions-sample-app-gradle/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java11"
+    "project_name": "Name of the project"
 }

--- a/java11/cookiecutter-aws-sam-step-functions-sample-app-maven/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-step-functions-sample-app-maven/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java11"
+    "project_name": "Name of the project"
 }

--- a/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/cookiecutter.json
+++ b/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java8"
+    "project_name": "Name of the project"
 }

--- a/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-gradle-v1
+      DockerTag: java8-gradle-v1
       DockerContext: ./HelloWorldFunction
       Dockerfile: Dockerfile
 

--- a/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/cookiecutter.json
+++ b/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java8"
+    "project_name": "Name of the project"
 }

--- a/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-maven-v1
+      DockerTag: java8-maven-v1
       DockerContext: ./HelloWorldFunction
       Dockerfile: Dockerfile
 

--- a/java8.al2-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/cookiecutter.json
+++ b/java8.al2-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java8.al2"
+    "project_name": "Name of the project"
 }

--- a/java8.al2-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-gradle-v1
+      DockerTag: java8.al2-gradle-v1
       DockerContext: ./HelloWorldFunction
       Dockerfile: Dockerfile
 

--- a/java8.al2-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/cookiecutter.json
+++ b/java8.al2-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java8.al2"
+    "project_name": "Name of the project"
 }

--- a/java8.al2-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-maven-v1
+      DockerTag: java8.al2-maven-v1
       DockerContext: ./HelloWorldFunction
       Dockerfile: Dockerfile
 

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-gradle/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-gradle/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Your EventBridge Starter app",
-    "runtime": "java8.al2"
+    "project_name": "Your EventBridge Starter app"
 }

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: helloworld.App::handleRequest
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: java8.al2
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-maven/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-maven/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Your EventBridge Starter app",
-    "runtime": "java8.al2"
+    "project_name": "Your EventBridge Starter app"
 }

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: helloworld.App::handleRequest
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: java8.al2
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/cookiecutter.json
@@ -1,6 +1,5 @@
 {
     "project_name": "Your EventBridge Starter app",
-    "runtime": "java8.al2",
     "function_name": "HelloWorldFunction",
     "AWS_Schema_registry": "aws.events",
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: {{cookiecutter.function_name}}
       Handler: helloworld.App::handleRequest
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: java8.al2
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/cookiecutter.json
@@ -1,6 +1,5 @@
 {
     "project_name": "Your EventBridge Starter app",
-    "runtime": "java8.al2",
     "function_name": "HelloWorldFunction",
     "AWS_Schema_registry": "aws.events",
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: helloworld.App::handleRequest
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: java8.al2
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/java8.al2/cookiecutter-aws-sam-hello-java-gradle/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-hello-java-gradle/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java8.al2"
+    "project_name": "Name of the project"
 }

--- a/java8.al2/cookiecutter-aws-sam-hello-java-maven/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-hello-java-maven/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java8.al2"
+    "project_name": "Name of the project"
 }

--- a/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-gradle/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-gradle/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java8.al2"
+    "project_name": "Name of the project"
 }

--- a/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-maven/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-maven/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java8.al2"
+    "project_name": "Name of the project"
 }

--- a/java8/cookiecutter-aws-sam-eventbridge-hello-java-gradle/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-eventbridge-hello-java-gradle/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Your EventBridge Starter app",
-    "runtime": "java8"
+    "project_name": "Your EventBridge Starter app"
 }

--- a/java8/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: helloworld.App::handleRequest
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: java8
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/java8/cookiecutter-aws-sam-eventbridge-hello-java-maven/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-eventbridge-hello-java-maven/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Your EventBridge Starter app",
-    "runtime": "java8"
+    "project_name": "Your EventBridge Starter app"
 }

--- a/java8/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: helloworld.App::handleRequest
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: java8
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/cookiecutter.json
@@ -1,6 +1,5 @@
 {
     "project_name": "Your EventBridge Starter app",
-    "runtime": "java8",
     "function_name": "HelloWorldFunction",
     "AWS_Schema_registry": "aws.events",
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",

--- a/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: {{cookiecutter.function_name}}
       Handler: helloworld.App::handleRequest
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: java8
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/cookiecutter.json
@@ -1,6 +1,5 @@
 {
     "project_name": "Your EventBridge Starter app",
-    "runtime": "java8",
     "function_name": "HelloWorldFunction",
     "AWS_Schema_registry": "aws.events",
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",

--- a/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: helloworld.App::handleRequest
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: java8
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/java8/cookiecutter-aws-sam-hello-java-gradle/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-hello-java-gradle/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java8"
+    "project_name": "Name of the project"
 }

--- a/java8/cookiecutter-aws-sam-hello-java-maven/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-hello-java-maven/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java8"
+    "project_name": "Name of the project"
 }

--- a/java8/cookiecutter-aws-sam-step-functions-sample-app-gradle/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-step-functions-sample-app-gradle/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java8"
+    "project_name": "Name of the project"
 }

--- a/java8/cookiecutter-aws-sam-step-functions-sample-app-maven/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-step-functions-sample-app-maven/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "java8"
+    "project_name": "Name of the project"
 }

--- a/nodejs10.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/cookiecutter.json
+++ b/nodejs10.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs10.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs10.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs10.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: nodejs10.x-v1
       DockerContext: ./hello-world
       Dockerfile: Dockerfile
 

--- a/nodejs10.x/cookiecutter-aws-sam-hello-nodejs/cookiecutter.json
+++ b/nodejs10.x/cookiecutter-aws-sam-hello-nodejs/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs10.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs10.x/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs10.x/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/template.yaml
@@ -16,11 +16,7 @@ Resources:
     Properties:
       CodeUri: hello-world/
       Handler: app.lambdaHandler
-      {%- if cookiecutter.runtime == 'nodejs8.10' %}
       Runtime: nodejs10.x
-      {%- else %}
-      Runtime: nodejs10.x
-      {%- endif %}
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/nodejs10.x/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs10.x/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/template.yaml
@@ -17,7 +17,7 @@ Resources:
       CodeUri: hello-world/
       Handler: app.lambdaHandler
       {%- if cookiecutter.runtime == 'nodejs8.10' %}
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: nodejs10.x
       {%- else %}
       Runtime: nodejs10.x
       {%- endif %}

--- a/nodejs10.x/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/nodejs10.x/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs10.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs10.x/cookiecutter-quick-start-cloudwatch-events/cookiecutter.json
+++ b/nodejs10.x/cookiecutter-quick-start-cloudwatch-events/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs10.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs10.x/cookiecutter-quick-start-from-scratch/cookiecutter.json
+++ b/nodejs10.x/cookiecutter-quick-start-from-scratch/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs10.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs10.x/cookiecutter-quick-start-s3/cookiecutter.json
+++ b/nodejs10.x/cookiecutter-quick-start-s3/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs10.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs10.x/cookiecutter-quick-start-sns/cookiecutter.json
+++ b/nodejs10.x/cookiecutter-quick-start-sns/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs10.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs10.x/cookiecutter-quick-start-sqs/cookiecutter.json
+++ b/nodejs10.x/cookiecutter-quick-start-sqs/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs10.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs10.x/cookiecutter-quick-start-web/cookiecutter.json
+++ b/nodejs10.x/cookiecutter-quick-start-web/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs10.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs12.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/cookiecutter.json
+++ b/nodejs12.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs12.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs12.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs12.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: nodejs12.x-v1
       DockerContext: ./hello-world
       Dockerfile: Dockerfile
 

--- a/nodejs12.x/cookiecutter-aws-sam-hello-nodejs/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-aws-sam-hello-nodejs/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs12.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs12.x/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs12.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs12.x/cookiecutter-quick-start-cloudwatch-events/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-quick-start-cloudwatch-events/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs12.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs12.x/cookiecutter-quick-start-from-scratch/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-quick-start-from-scratch/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs12.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs12.x/cookiecutter-quick-start-s3/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-quick-start-s3/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs12.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs12.x/cookiecutter-quick-start-sns/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-quick-start-sns/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs12.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs12.x/cookiecutter-quick-start-sqs/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-quick-start-sqs/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs12.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs12.x/cookiecutter-quick-start-web/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-quick-start-web/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs12.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs14.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/cookiecutter.json
+++ b/nodejs14.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs14.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs14.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs14.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: nodejs14.x-v1
       DockerContext: ./hello-world
       Dockerfile: Dockerfile
 

--- a/nodejs14.x/cookiecutter-aws-sam-hello-nodejs/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-aws-sam-hello-nodejs/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs14.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs14.x/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs14.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs14.x/cookiecutter-quick-start-cloudwatch-events/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-quick-start-cloudwatch-events/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs14.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs14.x/cookiecutter-quick-start-from-scratch/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-quick-start-from-scratch/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs14.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs14.x/cookiecutter-quick-start-s3/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-quick-start-s3/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs14.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs14.x/cookiecutter-quick-start-sns/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-quick-start-sns/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs14.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs14.x/cookiecutter-quick-start-sqs/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-quick-start-sqs/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs14.x"
+    "project_name": "Name of the project"
 }

--- a/nodejs14.x/cookiecutter-quick-start-web/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-quick-start-web/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "nodejs14.x"
+    "project_name": "Name of the project"
 }

--- a/python2.7-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
+++ b/python2.7-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python2.7"
+    "project_name": "Name of the project"
 }

--- a/python2.7-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/hello_world/Dockerfile
+++ b/python2.7-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/hello_world/Dockerfile
@@ -4,11 +4,11 @@ COPY app.py requirements.txt ./
 
 RUN curl https://bootstrap.pypa.io/2.7/get-pip.py -o get-pip.py
 
-RUN {{cookiecutter.runtime}} get-pip.py
+RUN python2.7 get-pip.py
 
 RUN rm -rf get-pip.y
 
-RUN {{cookiecutter.runtime}} -m pip install -r requirements.txt -t .
+RUN python2.7 -m pip install -r requirements.txt -t .
 
 # Command can be overwritten by providing a different command in the template directly.
 CMD ["app.lambda_handler"]

--- a/python2.7-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/python2.7-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: python2.7-v1
       DockerContext: ./hello_world
       Dockerfile: Dockerfile
 

--- a/python2.7/cookiecutter-aws-sam-hello-python/cookiecutter.json
+++ b/python2.7/cookiecutter-aws-sam-hello-python/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python2.7"
+    "project_name": "Name of the project"
 }

--- a/python2.7/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/python2.7/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python2.7"
+    "project_name": "Name of the project"
 }

--- a/python3.6-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
+++ b/python3.6-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.6"
+    "project_name": "Name of the project"
 }

--- a/python3.6-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/hello_world/Dockerfile
+++ b/python3.6-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/hello_world/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/lambda/python:3.6
 
 COPY app.py requirements.txt ./
 
-RUN {{cookiecutter.runtime}} -m pip install -r requirements.txt -t .
+RUN python3.6 -m pip install -r requirements.txt -t .
 
 # Command can be overwritten by providing a different command in the template directly.
 CMD ["app.lambda_handler"]

--- a/python3.6-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.6-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: python3.6-v1
       DockerContext: ./hello_world
       Dockerfile: Dockerfile
 

--- a/python3.6/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
+++ b/python3.6/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.6"
+    "project_name": "Name of the project"
 }

--- a/python3.6/cookiecutter-aws-sam-eventBridge-python/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.6/cookiecutter-aws-sam-eventBridge-python/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: hello_world_function
       Handler: hello_world/app.lambda_handler
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: python3.6
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/python3.6/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
+++ b/python3.6/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
@@ -1,6 +1,5 @@
 {
     "project_name": "Your EventBridge Starter app",
-    "runtime": "python3.6",
     "function_name": "hello_world_function",
     "AWS_Schema_registry": "aws.events",
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",

--- a/python3.6/cookiecutter-aws-sam-eventbridge-schema-app-python/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.6/cookiecutter-aws-sam-eventbridge-schema-app-python/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: {{ cookiecutter.function_name }}
       Handler: hello_world/app.lambda_handler
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: python3.6
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/python3.6/cookiecutter-aws-sam-hello-python/cookiecutter.json
+++ b/python3.6/cookiecutter-aws-sam-hello-python/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.6"
+    "project_name": "Name of the project"
 }

--- a/python3.6/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.6/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/template.yaml
@@ -16,13 +16,7 @@ Resources:
     Properties:
       CodeUri: hello_world/
       Handler: app.lambda_handler
-      {%- if cookiecutter.runtime == 'python2.7' %}
-      Runtime: python2.7
-      {%- elif cookiecutter.runtime == 'python3.6' %}
       Runtime: python3.6
-      {%- else %}
-      Runtime: python3.7
-      {%- endif %}
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/python3.6/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/python3.6/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.6"
+    "project_name": "Name of the project"
 }

--- a/python3.7-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
+++ b/python3.7-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.7"
+    "project_name": "Name of the project"
 }

--- a/python3.7-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/hello_world/Dockerfile
+++ b/python3.7-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/hello_world/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/lambda/python:3.7
 
 COPY app.py requirements.txt ./
 
-RUN {{cookiecutter.runtime}} -m pip install -r requirements.txt -t .
+RUN python3.7 -m pip install -r requirements.txt -t .
 
 # Command can be overwritten by providing a different command in the template directly.
 CMD ["app.lambda_handler"]

--- a/python3.7-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.7-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: python3.7-v1
       DockerContext: ./hello_world
       Dockerfile: Dockerfile
 

--- a/python3.7/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
+++ b/python3.7/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.7"
+    "project_name": "Name of the project"
 }

--- a/python3.7/cookiecutter-aws-sam-eventBridge-python/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.7/cookiecutter-aws-sam-eventBridge-python/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: hello_world_function
       Handler: hello_world/app.lambda_handler
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: python3.7
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/python3.7/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
+++ b/python3.7/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
@@ -1,6 +1,5 @@
 {
     "project_name": "Your EventBridge Starter app",
-    "runtime": "python3.7",
     "function_name": "hello_world_function",
     "AWS_Schema_registry": "aws.events",
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",

--- a/python3.7/cookiecutter-aws-sam-eventbridge-schema-app-python/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.7/cookiecutter-aws-sam-eventbridge-schema-app-python/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: {{ cookiecutter.function_name }}
       Handler: hello_world/app.lambda_handler
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: python3.7
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/python3.7/cookiecutter-aws-sam-hello-python/cookiecutter.json
+++ b/python3.7/cookiecutter-aws-sam-hello-python/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.7"
+    "project_name": "Name of the project"
 }

--- a/python3.7/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.7/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/template.yaml
@@ -16,13 +16,7 @@ Resources:
     Properties:
       CodeUri: hello_world/
       Handler: app.lambda_handler
-      {%- if cookiecutter.runtime == 'python2.7' %}
-      Runtime: python2.7
-      {%- elif cookiecutter.runtime == 'python3.6' %}
-      Runtime: python3.6
-      {%- else %}
       Runtime: python3.7
-      {%- endif %}
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/python3.7/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/python3.7/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.7"
+    "project_name": "Name of the project"
 }

--- a/python3.8-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
+++ b/python3.8-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.8"
+    "project_name": "Name of the project"
 }

--- a/python3.8-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/hello_world/Dockerfile
+++ b/python3.8-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/hello_world/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/lambda/python:3.8
 
 COPY app.py requirements.txt ./
 
-RUN {{cookiecutter.runtime}} -m pip install -r requirements.txt -t .
+RUN python3.8 -m pip install -r requirements.txt -t .
 
 # Command can be overwritten by providing a different command in the template directly.
 CMD ["app.lambda_handler"]

--- a/python3.8-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.8-image/cookiecutter-aws-sam-hello-python-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  {{cookiecutter.runtime}}
+  python3.8
 
   Sample SAM Template for {{cookiecutter.project_name}}
 
@@ -24,7 +24,7 @@ Resources:
     Metadata:
       Dockerfile: Dockerfile
       DockerContext: ./hello_world
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: python3.8-v1
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function

--- a/python3.8/cookiecutter-aws-sam-efs-python/cookiecutter.json
+++ b/python3.8/cookiecutter-aws-sam-efs-python/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.8"
+    "project_name": "Name of the project"
 }

--- a/python3.8/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
+++ b/python3.8/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.8"
+    "project_name": "Name of the project"
 }

--- a/python3.8/cookiecutter-aws-sam-eventBridge-python/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.8/cookiecutter-aws-sam-eventBridge-python/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: hello_world_function
       Handler: hello_world/app.lambda_handler
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: python3.8
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/python3.8/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
+++ b/python3.8/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
@@ -1,6 +1,5 @@
 {
     "project_name": "Your EventBridge Starter app",
-    "runtime": "python3.8",
     "function_name": "hello_world_function",
     "AWS_Schema_registry": "aws.events",
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",

--- a/python3.8/cookiecutter-aws-sam-eventbridge-schema-app-python/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.8/cookiecutter-aws-sam-eventbridge-schema-app-python/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: {{ cookiecutter.function_name }}
       Handler: hello_world/app.lambda_handler
-      Runtime: {{ cookiecutter.runtime }}
+      Runtime: python3.8
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/python3.8/cookiecutter-aws-sam-hello-python/cookiecutter.json
+++ b/python3.8/cookiecutter-aws-sam-hello-python/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.8"
+    "project_name": "Name of the project"
 }

--- a/python3.8/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/python3.8/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "python3.8"
+    "project_name": "Name of the project"
 }

--- a/ruby2.5-image/cookiecutter-aws-sam-hello-ruby-lambda-image/cookiecutter.json
+++ b/ruby2.5-image/cookiecutter-aws-sam-hello-ruby-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "ruby2.5"
+    "project_name": "Name of the project"
 }

--- a/ruby2.5-image/cookiecutter-aws-sam-hello-ruby-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/ruby2.5-image/cookiecutter-aws-sam-hello-ruby-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: ruby2.5-v1
       DockerContext: ./hello_world
       Dockerfile: Dockerfile
 

--- a/ruby2.5/cookiecutter-aws-sam-hello-ruby/cookiecutter.json
+++ b/ruby2.5/cookiecutter-aws-sam-hello-ruby/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "ruby2.5"
+    "project_name": "Name of the project"
 }

--- a/ruby2.5/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/ruby2.5/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "ruby2.5"
+    "project_name": "Name of the project"
 }

--- a/ruby2.7-image/cookiecutter-aws-sam-hello-ruby-lambda-image/cookiecutter.json
+++ b/ruby2.7-image/cookiecutter-aws-sam-hello-ruby-lambda-image/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "ruby2.7"
+    "project_name": "Name of the project"
 }

--- a/ruby2.7-image/cookiecutter-aws-sam-hello-ruby-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/ruby2.7-image/cookiecutter-aws-sam-hello-ruby-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -22,7 +22,7 @@ Resources:
             Path: /hello
             Method: get
     Metadata:
-      DockerTag: {{cookiecutter.runtime}}-v1
+      DockerTag: ruby2.7-v1
       DockerContext: ./hello_world
       Dockerfile: Dockerfile
 

--- a/ruby2.7/cookiecutter-aws-sam-hello-ruby/cookiecutter.json
+++ b/ruby2.7/cookiecutter-aws-sam-hello-ruby/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "ruby2.7"
+    "project_name": "Name of the project"
 }

--- a/ruby2.7/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/ruby2.7/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,3 @@
 {
-    "project_name": "Name of the project",
-    "runtime": "ruby2.7"
+    "project_name": "Name of the project"
 }


### PR DESCRIPTION
*Description of changes:*

now we rely on `runtime` key in each template's cookiecutter.json to test whether each generated zip-type template has the correct runtime. It is not reliable because we never reserve the key "runtime" for this purpose, and not all templates use this "runtime" parameter (like go1.x templates).

After discussing with @jfuss, this PR moves away from that and hardcode runtime directly into where it is needed. And we can test it directly in template.yaml. 

my steps:

### 1. replace `{{cookiecutter.runtime}}` with hardcode values

```py
import os
import json
import re
from pathlib import Path

pattern = re.compile(r'{{\s*cookiecutter\.runtime\s*}}')

with open('manifest.json') as f:
    manifect = json.load(f)

for _, templates in manifect.items():
    for template in templates:
        cookiecutter_json_path = Path(
            template["directory"], "cookiecutter.json"
        )
        cookiecutter_json = json.load(open(cookiecutter_json_path))
        runtime = cookiecutter_json['runtime']

        for root, dirs, files in os.walk(template["directory"], topdown=False):
            for name in files:
                file_path = os.path.join(root, name)
                with open(file_path, 'r') as f:
                    try:
                        content = f.read()
                        found = re.search(pattern, content)
                        # print(file_path, len(content))
                    except:
                        found = False
                        pass
                if found:
                    print(file_path)
                    print('\t', found.group(0))
                
                    with open(file_path, 'w') as f:
                        f.write(re.sub(pattern, runtime, content))
```

### 2. remove cookiecutter.runtime using search tools (are all jinja conditions)

### 3. Remove "runtime" from cookiecutter.json using this regex `,\n\s+"runtime":[^,\n]+`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
