### PR TITLE
Correct the option and template name to generate template -nodejs12, typescript template

### DIFF
--- a/nodejs12.x/cookiecutter-typescript-app-template/README.md
+++ b/nodejs12.x/cookiecutter-typescript-app-template/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a TypeScript Application using [Serverless App
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 12**: `sam init --runtime nodejs12.x --application-template typescript-app-template`
+* **NodeJS 12**: `sam init --runtime nodejs12.x --app-template quick-start-typescript-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the README.md, the suggested SAM init command results in an error. This change corrects the SAM init command to use the correct option and template name.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
