### PR TITLE
ci: Use standard:5.0 for java 8

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -38,9 +38,8 @@ batch:
     - identifier: UnitTestJava8
       buildspec: buildspecs/buildspec-unittest-java8.yml
       env:
-        # openjdk8 is only available in image aws/codebuild/standard:3.0
-        # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
-        image: aws/codebuild/standard:3.0
+        # We want to test Java 8 non-al2, so here standard is used instead of default (AL2).
+        image: aws/codebuild/standard:5.0
     - identifier: UnitTestJava8al2
       buildspec: buildspecs/buildspec-unittest-java8-al2.yml
     - identifier: UnitTestJava11

--- a/buildspecs/buildspec-unittest-java8.yml
+++ b/buildspecs/buildspec-unittest-java8.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      java: openjdk8
+      java: corretto8
 
     commands:
       - pip install --upgrade pip aws-sam-cli


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

aws/codebuild/standard:3.0 is no longer maintained after May 2021. https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
