### PR TITLE
ci: Fix codebuild failures

### DIFF
--- a/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -8,6 +8,7 @@ Description: >
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
+    MemorySize: 256
     Timeout: 20
 
 Resources:

--- a/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -8,6 +8,7 @@ Description: >
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
+    MemorySize: 256
     Timeout: 20
 
 Resources:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR tries to fix multiple CodeBuild issues:

#### Java 8 memory issue

Since 6 days ago (#98, a typescript only PR), java8 image templates' local invoke tests start to fail because of "out of memory" error. I cannot reproduce it locally, but increasing the memory size to 256 solves the problem.

```
...
Skip pulling image and use local one: helloworldfunction:rapid-1.23.0.
--


REPORT RequestId: 
178239ea-8b93-4edd-937a-b6e5792d16df  Init Duration: 0.13 ms  Duration: 
1424.45 ms    Billed Duration: 1500 ms    Memory Size: 128 MB Max Memory   Used: 128 MB
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
