### PR TITLE
Set GEM_HOME in Ruby runtimes' image Dockerfile templates

### DIFF
--- a/ruby2.5-image/cookiecutter-aws-sam-hello-ruby-lambda-image/{{cookiecutter.project_name}}/hello_world/Dockerfile
+++ b/ruby2.5-image/cookiecutter-aws-sam-hello-ruby-lambda-image/{{cookiecutter.project_name}}/hello_world/Dockerfile
@@ -2,6 +2,7 @@ FROM public.ecr.aws/lambda/ruby:2.5
 
 COPY app.rb Gemfile ./
 
+ENV GEM_HOME=${LAMBDA_TASK_ROOT}
 RUN bundle install
 
 # Command can be overwritten by providing a different command in the template directly.

--- a/ruby2.7-image/cookiecutter-aws-sam-hello-ruby-lambda-image/{{cookiecutter.project_name}}/hello_world/Dockerfile
+++ b/ruby2.7-image/cookiecutter-aws-sam-hello-ruby-lambda-image/{{cookiecutter.project_name}}/hello_world/Dockerfile
@@ -2,6 +2,7 @@ FROM public.ecr.aws/lambda/ruby:2.7
 
 COPY app.rb Gemfile ./
 
+ENV GEM_HOME=${LAMBDA_TASK_ROOT}
 RUN bundle install
 
 # Command can be overwritten by providing a different command in the template directly.


### PR DESCRIPTION
### Description of changes
This change sets the `GEM_HOME` environment variable before running `bundle install` in order to ensure that Gems are installed under `${LAMBDA_TASK_ROOT}` so that they are discoverable by the Lambda Ruby Runtime.

### Testing
#### Before (issue repro)
1. Create a Ruby 2.5 or 2.7 image project using the `sam init` "hello world" template
2. Uncomment `require 'httparty'` from `hello_world/app.rb`
3. Build and invoke the image locally with `sam build && sam local invoke`
This will throw an error similar to:
```
START RequestId: 7e3782c6-fb15-44e2-8c68-d466f700ee0d Version: $LATEST
Init error when loading handler app.lambda_handler
{
  "errorMessage": "cannot load such file -- httparty",
  "errorType": "Init<LoadError>",
  "stackTrace": [
    "/var/lang/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'",
    "/var/lang/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'",
    "/var/task/app.rb:1:in `<top (required)>'",
    "/var/lang/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'",
    "/var/lang/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'"
  ]
}
```


#### After
1. Create a Ruby 2.5 or 2.7 image project using the `sam init` "hello world" template
2. Uncomment `require 'httparty'` from `hello_world/app.rb`
3. **Add the change from this CR to the `Dockerfile` (ie. `ENV GEM_HOME=${LAMBDA_TASK_ROOT` before `RUN bundle install`)**
4. Build and invoke the image locally with `sam build && sam local invoke`
This will result in a successful invocation as the dependencies are installed in a discoverable path:
```
START RequestId: 85f32f38-4043-4bca-99c0-228734fe650e Version: $LATEST
END RequestId: 85f32f38-4043-4bca-99c0-228734fe650e
REPORT RequestId: 85f32f38-4043-4bca-99c0-228734fe650e  Init Duration: 0.22 ms  Duration: 382.71 ms     Billed Duration: 400 ms Memory Size: 128 MB     Max Memory Used: 128 MB
{"statusCode":200,"body":"{\"message\":\"Hello World!\"}"}
```


----------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
