### PR TITLE
Changed from Fn::GetAtt to !GetAtt

### DIFF
--- a/nodejs14.x/cookiecutter-quick-start-sqs/{{cookiecutter.project_name}}/template.yml
+++ b/nodejs14.x/cookiecutter-quick-start-sqs/{{cookiecutter.project_name}}/template.yml
@@ -34,7 +34,7 @@ Resources:
         SQSQueueEvent:
           Type: SQS
           Properties:
-            Queue: Fn::GetAtt SimpleQueue.Arn
+            Queue: !GetAtt SimpleQueue.Arn
       MemorySize: 128
       Timeout: 25 # Chosen to be less than the default SQS Visibility Timeout of 30 seconds
       Policies:


### PR DESCRIPTION
Cloudformation gives the following error using Fn::GetAtt instead of !GetAtt.

Resource handler returned message: "Model validation failed (#/EventSourceArn: failed validation constraint for keyword [pattern])"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
