### PR TITLE
chore: Bump Python 3.8 ML APIGW Tensorflow to 2.5.1

### DIFF
--- a/python3.8-image/cookiecutter-ml-apigw-tensorflow/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.8-image/cookiecutter-ml-apigw-tensorflow/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow==2.4.2
+tensorflow==2.5.1
 pillow==8.2.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
