### PR TITLE
Give Lambda permissions to poll the SQS queue

### DIFF
--- a/nodejs10.x/cookiecutter-quick-start-sqs/{{cookiecutter.project_name}}/template.yml
+++ b/nodejs10.x/cookiecutter-quick-start-sqs/{{cookiecutter.project_name}}/template.yml
@@ -40,3 +40,6 @@ Resources:
       Policies:
         # Give Lambda basic execution Permission to the helloFromLambda
         - AWSLambdaBasicExecutionRole
+        # Give Lambda permissions to poll the SQS queue
+        - SQSPollerPolicy:
+            QueueName: !GetAtt SimpleQueue.QueueName

--- a/nodejs12.x/cookiecutter-quick-start-sqs/{{cookiecutter.project_name}}/template.yml
+++ b/nodejs12.x/cookiecutter-quick-start-sqs/{{cookiecutter.project_name}}/template.yml
@@ -40,3 +40,6 @@ Resources:
       Policies:
         # Give Lambda basic execution Permission to the helloFromLambda
         - AWSLambdaBasicExecutionRole
+        # Give Lambda permissions to poll the SQS queue
+        - SQSPollerPolicy:
+            QueueName: !GetAtt SimpleQueue.QueueName

--- a/nodejs14.x/cookiecutter-quick-start-sqs/{{cookiecutter.project_name}}/template.yml
+++ b/nodejs14.x/cookiecutter-quick-start-sqs/{{cookiecutter.project_name}}/template.yml
@@ -40,3 +40,6 @@ Resources:
       Policies:
         # Give Lambda basic execution Permission to the helloFromLambda
         - AWSLambdaBasicExecutionRole
+        # Give Lambda permissions to poll the SQS queue
+        - SQSPollerPolicy:
+            QueueName: !GetAtt SimpleQueue.QueueName


### PR DESCRIPTION
[Issue #138](https://github.com/aws/aws-sam-cli-app-templates/issues/138)

Added the missing policy to enable Lambda to poll the sample SQS queue.
