### PR TITLE
Updated .NET Core 3.1 Lambda examples to use new default serializer

### DIFF
--- a/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/Function.cs
+++ b/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/Function.cs
@@ -1,14 +1,13 @@
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Net.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
 
-using Amazon.Lambda.Core;
 using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.Core;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
 namespace HelloWorld
 {
@@ -40,7 +39,7 @@ namespace HelloWorld
 
             return new APIGatewayProxyResponse
             {
-                Body = JsonConvert.SerializeObject(body),
+                Body = JsonSerializer.Serialize(body),
                 StatusCode = 200,
                 Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
             };

--- a/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -6,9 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/FunctionTest.cs
+++ b/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/FunctionTest.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Net.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+
 using Xunit;
-using Amazon.Lambda.TestUtilities;
 using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.TestUtilities;
 
 namespace HelloWorld.Tests
 {
@@ -39,7 +39,7 @@ namespace HelloWorld.Tests
 
             var expectedResponse = new APIGatewayProxyResponse
             {
-                Body = JsonConvert.SerializeObject(body),
+                Body = JsonSerializer.Serialize(body),
                 StatusCode = 200,
                 Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
             };

--- a/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/Function.cs
+++ b/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/Function.cs
@@ -1,14 +1,13 @@
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Net.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
 
-using Amazon.Lambda.Core;
 using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.Core;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
 namespace HelloWorld
 {
@@ -40,7 +39,7 @@ namespace HelloWorld
 
             return new APIGatewayProxyResponse
             {
-                Body = JsonConvert.SerializeObject(body),
+                Body = JsonSerializer.Serialize(body),
                 StatusCode = 200,
                 Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
             };

--- a/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -6,10 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.3.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
   </ItemGroup>
 </Project>
-

--- a/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/FunctionTest.cs
+++ b/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/FunctionTest.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Net.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+
 using Xunit;
-using Amazon.Lambda.TestUtilities;
 using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.TestUtilities;
 
 namespace HelloWorld.Tests
 {
@@ -39,7 +39,7 @@ namespace HelloWorld.Tests
 
             var expectedResponse = new APIGatewayProxyResponse
             {
-                Body = JsonConvert.SerializeObject(body),
+                Body = JsonSerializer.Serialize(body),
                 StatusCode = 200,
                 Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
             };

--- a/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/Function.cs
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/Function.cs
@@ -1,14 +1,13 @@
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Net.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
 
-using Amazon.Lambda.Core;
 using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.Core;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
 namespace HelloWorld
 {
@@ -40,7 +39,7 @@ namespace HelloWorld
 
             return new APIGatewayProxyResponse
             {
-                Body = JsonConvert.SerializeObject(body),
+                Body = JsonSerializer.Serialize(body),
                 StatusCode = 200,
                 Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
             };

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -6,10 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.3.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
   </ItemGroup>
 </Project>
-

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/FunctionTest.cs
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/FunctionTest.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Net.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+
 using Xunit;
-using Amazon.Lambda.TestUtilities;
 using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.TestUtilities;
 
 namespace HelloWorld.Tests
 {
@@ -39,7 +39,7 @@ namespace HelloWorld.Tests
 
             var expectedResponse = new APIGatewayProxyResponse
             {
-                Body = JsonConvert.SerializeObject(body),
+                Body = JsonSerializer.Serialize(body),
                 StatusCode = 200,
                 Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
             };

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockBuyer/Function.cs
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockBuyer/Function.cs
@@ -2,22 +2,22 @@ using Amazon.Lambda.Core;
 using System;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
 namespace StockBuyer
 {
     public class StockEvent
     {
-        public int stockPrice;
+        public int stockPrice { get; set; }
     }
 
     public class TransactionResult
     {
-        public string id;
-        public string price;
-        public string type;
-        public string qty;
-        public string timestamp;
+        public string id { get; set; }
+        public string price { get; set; }
+        public string type { get; set; }
+        public string qty { get; set; }
+        public string timestamp { get; set; }
     }
 
     public class Function

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockBuyer/StockBuyer.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockBuyer/StockBuyer.csproj
@@ -6,8 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
   </ItemGroup>
 </Project>
-

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockChecker/Function.cs
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockChecker/Function.cs
@@ -2,13 +2,13 @@ using System;
 using Amazon.Lambda.Core;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
 namespace StockChecker
 {
     public class StockEvent
     {
-        public int stockPrice;
+        public int stockPrice { get; set; }
     }
 
     public class Function

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockChecker/StockChecker.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockChecker/StockChecker.csproj
@@ -6,8 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
   </ItemGroup>
 </Project>
-

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockSeller/Function.cs
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockSeller/Function.cs
@@ -2,22 +2,22 @@ using Amazon.Lambda.Core;
 using System;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
 namespace StockSeller
 {
     public class StockEvent
     {
-        public int stockPrice;
+        public int stockPrice { get; set; }
     }
 
     public class TransactionResult
     {
-        public string id;
-        public string price;
-        public string type;
-        public string qty;
-        public string timestamp;
+        public string id { get; set; }
+        public string price { get; set; }
+        public string type { get; set; }
+        public string qty { get; set; }
+        public string timestamp { get; set; }
     }
 
     public class Function

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockSeller/StockSeller.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/functions/StockSeller/StockSeller.csproj
@@ -6,8 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.8.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
   </ItemGroup>
 </Project>
-

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockBuyer.Test/StockBuyer.Tests.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockBuyer.Test/StockBuyer.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockChecker.Test/StockChecker.Tests.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockChecker.Test/StockChecker.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockSeller.Test/StockSeller.Tests.csproj
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/tests/StockSeller.Test/StockSeller.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>


### PR DESCRIPTION
*Description of changes:* Updated dotnetcore3.1, dotnetcore3.1-image and dotnet5.0-image example applications to use the AWS recommended default serializer for dotnetcore3.1, Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer.

Also updated the NuGet package references for Amazon.Lambda.Core and Amazon.Lambda.APIGatewayEvents to the latest version where applicable.

This includes the HelloWorld (APIGW + Lambda) and StockTrading (StepFunctions + Lambda) example applications.

By removing the dependency on Newtonsoft.JSON library, the new zip package for HelloWorld reduced from 299KB to 44KB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
