### PR TITLE
correct --application-template to --app-template in readme

### DIFF
--- a/nodejs12.x/cookiecutter-quick-start-cloudwatch-events/README.md
+++ b/nodejs12.x/cookiecutter-quick-start-cloudwatch-events/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a NodeJS CloudWatch Events Quick Start Applica
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 12**: `sam init --runtime nodejs12.x --application-template quick-start-cloudwatch-events --name cwe-app`
+* **NodeJS 12**: `sam init --runtime nodejs12.x --app-template quick-start-cloudwatch-events --name cwe-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 

--- a/nodejs12.x/cookiecutter-quick-start-from-scratch/README.md
+++ b/nodejs12.x/cookiecutter-quick-start-from-scratch/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a NodeJS Basic Quick Start Application using [
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 12**: `sam init --runtime nodejs12.x --application-template quick-start-from-scratch --name sam-app`
+* **NodeJS 12**: `sam init --runtime nodejs12.x --app-template quick-start-from-scratch --name sam-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 

--- a/nodejs12.x/cookiecutter-quick-start-s3/README.md
+++ b/nodejs12.x/cookiecutter-quick-start-s3/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a NodeJS S3 Quick Start Application using [Ser
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 12**: `sam init --runtime nodejs12.x --application-template quick-start-s3 --name s3-app`
+* **NodeJS 12**: `sam init --runtime nodejs12.x --app-template quick-start-s3 --name s3-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 

--- a/nodejs12.x/cookiecutter-quick-start-sns/README.md
+++ b/nodejs12.x/cookiecutter-quick-start-sns/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a NodeJS SNS Quick Start Application using [Se
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 12**: `sam init --runtime nodejs12.x --application-template quick-start-sns --name sns-app`
+* **NodeJS 12**: `sam init --runtime nodejs12.x --app-template quick-start-sns --name sns-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 

--- a/nodejs12.x/cookiecutter-quick-start-sqs/README.md
+++ b/nodejs12.x/cookiecutter-quick-start-sqs/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a NodeJS SQS Quick Start Application using [Se
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 12**: `sam init --runtime nodejs12.x --application-template quick-start-sqs --name sqs-app`
+* **NodeJS 12**: `sam init --runtime nodejs12.x --app-template quick-start-sqs --name sqs-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 

--- a/nodejs12.x/cookiecutter-quick-start-web/README.md
+++ b/nodejs12.x/cookiecutter-quick-start-web/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a NodeJS Quick Start Web Application using [Se
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 12**: `sam init --runtime nodejs12.x --application-template quick-start-web --name web-app`
+* **NodeJS 12**: `sam init --runtime nodejs12.x --app-template quick-start-web --name web-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 

--- a/nodejs12.x/cookiecutter-typescript-app-template/README.md
+++ b/nodejs12.x/cookiecutter-typescript-app-template/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a TypeScript Application using [Serverless App
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 12**: `sam init --runtime nodejs12.x --application-template typescript-app-template`
+* **NodeJS 12**: `sam init --runtime nodejs12.x --app-template typescript-app-template`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 

--- a/nodejs14.x/cookiecutter-quick-start-cloudwatch-events/README.md
+++ b/nodejs14.x/cookiecutter-quick-start-cloudwatch-events/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a NodeJS CloudWatch Events Quick Start Applica
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 14**: `sam init --runtime nodejs14.x --application-template quick-start-cloudwatch-events --name cwe-app`
+* **NodeJS 14**: `sam init --runtime nodejs14.x --app-template quick-start-cloudwatch-events --name cwe-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 

--- a/nodejs14.x/cookiecutter-quick-start-from-scratch/README.md
+++ b/nodejs14.x/cookiecutter-quick-start-from-scratch/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a NodeJS Basic Quick Start Application using [
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 14**: `sam init --runtime nodejs14.x --application-template quick-start-from-scratch --name sam-app`
+* **NodeJS 14**: `sam init --runtime nodejs14.x --app-template quick-start-from-scratch --name sam-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 

--- a/nodejs14.x/cookiecutter-quick-start-s3/README.md
+++ b/nodejs14.x/cookiecutter-quick-start-s3/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a NodeJS S3 Quick Start Application using [Ser
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 14**: `sam init --runtime nodejs14.x --application-template quick-start-s3 --name s3-app`
+* **NodeJS 14**: `sam init --runtime nodejs14.x --app-template quick-start-s3 --name s3-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 

--- a/nodejs14.x/cookiecutter-quick-start-sns/README.md
+++ b/nodejs14.x/cookiecutter-quick-start-sns/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a NodeJS SNS Quick Start Application using [Se
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 14**: `sam init --runtime nodejs14.x --application-template quick-start-sns --name sns-app`
+* **NodeJS 14**: `sam init --runtime nodejs14.x --app-template quick-start-sns --name sns-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 

--- a/nodejs14.x/cookiecutter-quick-start-sqs/README.md
+++ b/nodejs14.x/cookiecutter-quick-start-sqs/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a NodeJS SQS Quick Start Application using [Se
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 14**: `sam init --runtime nodejs14.x --application-template quick-start-sqs --name sqs-app`
+* **NodeJS 14**: `sam init --runtime nodejs14.x --app-template quick-start-sqs --name sqs-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 

--- a/nodejs14.x/cookiecutter-quick-start-web/README.md
+++ b/nodejs14.x/cookiecutter-quick-start-web/README.md
@@ -10,7 +10,7 @@ A cookiecutter template to create a NodeJS Quick Start Web Application using [Se
 
 Generate a boilerplate template in your current project directory using the following syntax:
 
-* **NodeJS 14**: `sam init --runtime nodejs14.x --application-template quick-start-web --name web-app`
+* **NodeJS 14**: `sam init --runtime nodejs14.x --app-template quick-start-web --name web-app`
 
 > **NOTE**: ``--name`` allows you to specify a different project folder name
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Noticed a few readmes with incorrect command line argument changed --application-template to --app-template in readme


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
