### PR TITLE
fix: argument orders in assertEquals

### DIFF
--- a/java11-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/java11-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -11,8 +11,8 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     APIGatewayProxyResponseEvent result = app.handleRequest(null, null);
-    assertEquals(result.getStatusCode().intValue(), 200);
-    assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+    assertEquals(200, result.getStatusCode().intValue());
+    assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);
     assertTrue(content.contains("\"message\""));

--- a/java11-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/java11-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -11,8 +11,8 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     APIGatewayProxyResponseEvent result = app.handleRequest(null, null);
-    assertEquals(result.getStatusCode().intValue(), 200);
-    assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+    assertEquals(200, result.getStatusCode().intValue());
+    assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);
     assertTrue(content.contains("\"message\""));

--- a/java11/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/java11/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -11,8 +11,8 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     APIGatewayProxyResponseEvent result = app.handleRequest(null, null);
-    assertEquals(result.getStatusCode().intValue(), 200);
-    assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+    assertEquals(200, result.getStatusCode().intValue());
+    assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);
     assertTrue(content.contains("\"message\""));

--- a/java11/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/java11/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -11,8 +11,8 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     APIGatewayProxyResponseEvent result = app.handleRequest(null, null);
-    assertEquals(result.getStatusCode().intValue(), 200);
-    assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+    assertEquals(200, result.getStatusCode().intValue());
+    assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);
     assertTrue(content.contains("\"message\""));

--- a/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -11,8 +11,8 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     APIGatewayProxyResponseEvent result = app.handleRequest(null, null);
-    assertEquals(result.getStatusCode().intValue(), 200);
-    assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+    assertEquals(200, result.getStatusCode().intValue());
+    assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);
     assertTrue(content.contains("\"message\""));

--- a/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -11,8 +11,8 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     APIGatewayProxyResponseEvent result = app.handleRequest(null, null);
-    assertEquals(result.getStatusCode().intValue(), 200);
-    assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+    assertEquals(200, result.getStatusCode().intValue());
+    assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);
     assertTrue(content.contains("\"message\""));

--- a/java8.al2-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/java8.al2-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -11,8 +11,8 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     APIGatewayProxyResponseEvent result = app.handleRequest(null, null);
-    assertEquals(result.getStatusCode().intValue(), 200);
-    assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+    assertEquals(200, result.getStatusCode().intValue());
+    assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);
     assertTrue(content.contains("\"message\""));

--- a/java8.al2-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/java8.al2-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -11,8 +11,8 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     APIGatewayProxyResponseEvent result = app.handleRequest(null, null);
-    assertEquals(result.getStatusCode().intValue(), 200);
-    assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+    assertEquals(200, result.getStatusCode().intValue());
+    assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);
     assertTrue(content.contains("\"message\""));

--- a/java8.al2/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/java8.al2/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -10,8 +10,8 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     GatewayResponse result = (GatewayResponse) app.handleRequest(null, null);
-    assertEquals(result.getStatusCode(), 200);
-    assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+    assertEquals(200, result.getStatusCode());
+    assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);
     assertTrue(content.contains("\"message\""));

--- a/java8.al2/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/java8.al2/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -10,8 +10,8 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     GatewayResponse result = (GatewayResponse) app.handleRequest(null, null);
-    assertEquals(result.getStatusCode(), 200);
-    assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+    assertEquals(200, result.getStatusCode());
+    assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);
     assertTrue(content.contains("\"message\""));

--- a/java8/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/java8/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -11,8 +11,8 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     APIGatewayProxyResponseEvent result = app.handleRequest(null, null);
-    assertEquals(result.getStatusCode().intValue(), 200);
-    assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+    assertEquals(200, result.getStatusCode().intValue());
+    assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);
     assertTrue(content.contains("\"message\""));

--- a/java8/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
+++ b/java8/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/test/java/helloworld/AppTest.java
@@ -11,8 +11,8 @@ public class AppTest {
   public void successfulResponse() {
     App app = new App();
     APIGatewayProxyResponseEvent result = app.handleRequest(null, null);
-    assertEquals(result.getStatusCode().intValue(), 200);
-    assertEquals(result.getHeaders().get("Content-Type"), "application/json");
+    assertEquals(200, result.getStatusCode().intValue());
+    assertEquals("application/json", result.getHeaders().get("Content-Type"));
     String content = result.getBody();
     assertNotNull(content);
     assertTrue(content.contains("\"message\""));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
argument orders in assertEquals in the testing code are fixed. Formerly, they reported assertion errors like "expected:<500> but was:<200>"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
