### PR TITLE
docs: go1.x README

### DIFF
--- a/go1.x-image/cookiecutter-aws-sam-hello-golang-lambda-image/{{cookiecutter.project_name}}/README.md
+++ b/go1.x-image/cookiecutter-aws-sam-hello-golang-lambda-image/{{cookiecutter.project_name}}/README.md
@@ -4,7 +4,6 @@ This is a sample template for {{ cookiecutter.project_name }} - Below is a brief
 
 ```bash
 .
-├── Makefile                    <-- Make to automate build
 ├── README.md                   <-- This instructions file
 ├── hello-world                 <-- Source code for a lambda function
 │   ├── main.go                 <-- Lambda function code


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sam-cli-app-templates/issues/149

*Description of changes:* Go uses `go` instead of a Makefile.

Match `go1.x` README to directory structure.