### PR TITLE
fix: Set get-pip URL to 3.6

### DIFF
--- a/buildspecs/buildspec-unittest-python3.6.yml
+++ b/buildspecs/buildspec-unittest-python3.6.yml
@@ -16,7 +16,7 @@ phases:
       # upgrade sam-cli
       - pip install --upgrade aws-sam-cli
       # install pip
-      - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+      - curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py
       - python3.6 get-pip.py
       # install requirements
       - python3.6 -m pip install -r requirements.txt


### PR DESCRIPTION
*Issue #, if available:*
CodeBuild CI is broken due to unable to get get-pip.py for 3.6.

*Description of changes:*
Changed URL in 3.6 build.spec to download the older version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
