### PR TITLE
fix(dotnet6): Set .NET6 example as Hello-World

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -72,7 +72,7 @@
       "dependencyManager": "cli-package",
       "appTemplate": "hello-world",
       "packageType": "Zip",
-      "useCaseName": "Serverless API"
+      "useCaseName": "Hello World Example"
     },
     {
       "directory": "dotnet6/cookiecutter-aws-sam-hello-step-functions-sample-app",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Modify the basic template for .NET6 to show up as "Hello World Example" instead of "Serverless API"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


Testing `sam init` locally with this new version:

```
$ samdev init

You can preselect a particular runtime or package type when using the `sam init` experience.
Call `sam init --help` to learn more.

Which template source would you like to use?
        1 - AWS Quick Start Templates
        2 - Custom Template Location
Choice: 1

Choose an AWS Quick Start application template
        1 - Hello World Example
        2 - Multi-step workflow
        3 - Serverless API
        4 - Scheduled task
        5 - Standalone function
        6 - Data processing
        7 - Infrastructure event management
        8 - Machine Learning
Template: 1

 Use the most popular runtime and package type? (Python and zip) [y/N]: n

Which runtime would you like to use?
        1 - dotnet6
        2 - dotnet5.0
        3 - dotnetcore3.1
        4 - go1.x
        5 - java11
        6 - java8.al2
        7 - java8
        8 - nodejs14.x
        9 - nodejs12.x
        10 - python3.9
        11 - python3.8
        12 - python3.7
        13 - python3.6
        14 - ruby2.7
Runtime: 1

```