### PR TITLE
upgrade tensorflow version to 2.8.0

### DIFF
--- a/python3.8-image/cookiecutter-ml-apigw-tensorflow/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.8-image/cookiecutter-ml-apigw-tensorflow/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow==2.5.3
+tensorflow==2.8.0
 pillow==9.0.0

--- a/python3.8-image/cookiecutter-ml-apigw-tensorflow/{{cookiecutter.project_name}}/training.ipynb
+++ b/python3.8-image/cookiecutter-ml-apigw-tensorflow/{{cookiecutter.project_name}}/training.ipynb
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -q tensorflow==2.4.0"
+    "! pip install -q tensorflow==2.8.0"
    ]
   },
   {

--- a/python3.9-image/cookiecutter-ml-apigw-tensorflow/cookiecutter.json
+++ b/python3.9-image/cookiecutter-ml-apigw-tensorflow/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "digit_classifier",
-  "tensorflow_version": "2.4.1",
+  "tensorflow_version": "2.8.0",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [


### PR DESCRIPTION
The python 3.9 - Machine Learning - Tensorflow template breaks during the sam build process. Tensorflow 2.4.0 appears no longer to be available. This PR upgrades the python 3.9 template to tensorflow 2.8.0 to fix this problem. It also upgrades the 3.8 template to tensorflow 2.8.0 for housekeeping.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
