### PR TITLE
fix: bump jackson version for fixing vulnerability

### DIFF
--- a/java11/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java11/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,10 +7,11 @@ repositories {
 }
 
 dependencies {
+    ext.jacksonVersion = '2.13.2'
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
+    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java11/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java11/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -9,6 +9,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <jackson.version>2.13.2</jackson.version>
     </properties>
 
     <dependencies>
@@ -26,17 +27,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 

--- a/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
+++ b/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
@@ -7,10 +7,11 @@ repositories {
 }
 
 dependencies {
+    ext.jacksonVersion = '2.13.2'
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
+    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
+++ b/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
@@ -9,6 +9,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <jackson.version>2.13.2</jackson.version>
     </properties>
 
     <dependencies>
@@ -26,17 +27,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,10 +7,11 @@ repositories {
 }
 
 dependencies {
+    ext.jacksonVersion = '2.13.2'
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
+    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -9,6 +9,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <jackson.version>2.13.2</jackson.version>
     </properties>
 
     <dependencies>
@@ -26,17 +27,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
@@ -7,10 +7,11 @@ repositories {
 }
 
 dependencies {
+    ext.jacksonVersion = '2.13.2'
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
+    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
@@ -9,6 +9,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <jackson.version>2.13.2</jackson.version>
     </properties>
 
     <dependencies>
@@ -26,17 +27,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 

--- a/java8/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,10 +7,11 @@ repositories {
 }
 
 dependencies {
+    ext.jacksonVersion = '2.13.2'
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
+    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java8/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -9,6 +9,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <jackson.version>2.13.2</jackson.version>
     </properties>
 
     <dependencies>
@@ -26,17 +27,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 

--- a/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
+++ b/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
@@ -7,10 +7,11 @@ repositories {
 }
 
 dependencies {
+    ext.jacksonVersion = '2.13.2'
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
+    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
+++ b/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
@@ -9,6 +9,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <jackson.version>2.13.2</jackson.version>
     </properties>
 
     <dependencies>
@@ -26,17 +27,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.13.1</version>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
*Issue #, if available:*
Bumping jackson version to fix security vulnerability; https://snyk.io/vuln/maven:com.fasterxml.jackson.core%3Ajackson-databind

*Description of changes:*
Bump jackson library versions from `2.13.1` to `2.13.2` in java templates


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
