### PR TITLE
Adding the tiered compilation environment variable to decrease cold s…

### DIFF
--- a/java11-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java11-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -21,6 +21,9 @@ Resources:
         - {{arch}}
       {%- endfor %}
       {%- endif %}
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/java11-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java11-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -21,6 +21,9 @@ Resources:
         - {{arch}}
       {%- endfor %}
       {%- endif %}
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/java11/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -26,6 +26,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/java11/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -26,6 +26,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -26,6 +26,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -26,6 +26,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/java11/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -27,6 +27,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/java11/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -27,6 +27,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/java11/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -46,6 +46,9 @@ Resources:
       {%- endfor %}
       {%- endif %}
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   StockSellerFunction:
     Type: AWS::Serverless::Function
@@ -60,6 +63,9 @@ Resources:
       {%- endfor %}
       {%- endif %}
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   StockBuyerFunction:
     Type: AWS::Serverless::Function
@@ -74,6 +80,9 @@ Resources:
       {%- endfor %}
       {%- endif %}
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   TransactionTable:
     Type: AWS::Serverless::SimpleTable # More info about SimpleTable Resource: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-simpletable.html

--- a/java11/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/template.yaml
@@ -46,6 +46,9 @@ Resources:
       {%- endfor %}
       {%- endif %}
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   StockSellerFunction:
     Type: AWS::Serverless::Function
@@ -60,6 +63,9 @@ Resources:
       {%- endfor %}
       {%- endif %}
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   StockBuyerFunction:
     Type: AWS::Serverless::Function
@@ -74,6 +80,9 @@ Resources:
       {%- endfor %}
       {%- endif %}
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   TransactionTable:
     Type: AWS::Serverless::SimpleTable # More info about SimpleTable Resource: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-simpletable.html

--- a/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -15,6 +15,9 @@ Resources:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
       PackageType: Image
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -15,6 +15,9 @@ Resources:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
       PackageType: Image
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/java8.al2-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -21,6 +21,9 @@ Resources:
         - {{arch}}
       {%- endfor %}
       {%- endif %}
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/java8.al2-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/{{cookiecutter.project_name}}/template.yaml
@@ -21,6 +21,9 @@ Resources:
         - {{arch}}
       {%- endfor %}
       {%- endif %}
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -26,6 +26,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -26,6 +26,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -26,6 +26,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -26,6 +26,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/java8.al2/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -27,6 +27,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/java8.al2/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -27,6 +27,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -46,6 +46,9 @@ Resources:
       {%- endfor %}
       {%- endif %}
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   StockSellerFunction:
     Type: AWS::Serverless::Function
@@ -60,6 +63,9 @@ Resources:
       {%- endfor %}
       {%- endif %}
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   StockBuyerFunction:
     Type: AWS::Serverless::Function
@@ -74,6 +80,9 @@ Resources:
       {%- endfor %}
       {%- endif %}
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   TransactionTable:
     Type: AWS::Serverless::SimpleTable # More info about SimpleTable Resource: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-simpletable.html

--- a/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/template.yaml
@@ -46,6 +46,9 @@ Resources:
       {%- endfor %}
       {%- endif %}
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   StockSellerFunction:
     Type: AWS::Serverless::Function
@@ -60,6 +63,9 @@ Resources:
       {%- endfor %}
       {%- endif %}
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   StockBuyerFunction:
     Type: AWS::Serverless::Function
@@ -74,6 +80,9 @@ Resources:
       {%- endfor %}
       {%- endif %}
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   TransactionTable:
     Type: AWS::Serverless::SimpleTable # More info about SimpleTable Resource: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-simpletable.html

--- a/java8/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8/cookiecutter-aws-sam-eventbridge-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -20,6 +20,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/java8/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8/cookiecutter-aws-sam-eventbridge-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -20,6 +20,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -20,6 +20,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -20,6 +20,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: CloudWatchEvent # More info about CloudWatchEvent Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchevent

--- a/java8/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -21,6 +21,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/java8/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -21,6 +21,7 @@ Resources:
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/java8/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8/cookiecutter-aws-sam-step-functions-sample-app-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -40,6 +40,9 @@ Resources:
       Handler: StockChecker.src.main.java.stockChecker.App::handleRequest
       Runtime: java8
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   StockSellerFunction:
     Type: AWS::Serverless::Function
@@ -48,6 +51,9 @@ Resources:
       Handler: StockSeller.src.main.java.stockSeller.App::handleRequest
       Runtime: java8
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   StockBuyerFunction:
     Type: AWS::Serverless::Function
@@ -56,6 +62,9 @@ Resources:
       Handler: StockBuyer.src.main.java.stockBuyer.App::handleRequest
       Runtime: java8
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   TransactionTable:
     Type: AWS::Serverless::SimpleTable # More info about SimpleTable Resource: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-simpletable.html

--- a/java8/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8/cookiecutter-aws-sam-step-functions-sample-app-maven/{{cookiecutter.project_name}}/template.yaml
@@ -40,6 +40,9 @@ Resources:
       Handler: StockChecker.src.main.java.stockChecker.App::handleRequest
       Runtime: java8
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   StockSellerFunction:
     Type: AWS::Serverless::Function
@@ -48,6 +51,9 @@ Resources:
       Handler: StockSeller.src.main.java.stockSeller.App::handleRequest
       Runtime: java8
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   StockBuyerFunction:
     Type: AWS::Serverless::Function
@@ -56,6 +62,9 @@ Resources:
       Handler: StockBuyer.src.main.java.stockBuyer.App::handleRequest
       Runtime: java8
       MemorySize: 512
+      Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
+        Variables:
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 # More info about tiered compilation https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/
 
   TransactionTable:
     Type: AWS::Serverless::SimpleTable # More info about SimpleTable Resource: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-simpletable.html


### PR DESCRIPTION
Adding the tiered compilation environment variable to decrease cold start times (https://aws.amazon.com/blogs/compute/optimizing-aws-lambda-function-performance-for-java/)

*Issue #, if available:*
https://github.com/aws/aws-sam-cli-app-templates/issues/234

*Description of changes:*
I've added the `JAVA_TOOL_OPTIONS` env var with the tiered compilation set to level 1 in all the Java projects. Where there was existing env vars I've added the new one and left any originals. Where there was no env vars, I added the new section including the comment for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
