### PR TITLE
fix: add nodejs16 image type to the manifest

### DIFF
--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -419,6 +419,16 @@
       "useCaseName": "Serverless API"
     }
   ],
+  "amazon/nodejs16.x-base": [
+    {
+      "directory": "nodejs16.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image",
+      "displayName": "Hello World Image Example",
+      "dependencyManager": "npm",
+      "appTemplate": "hello-world-lambda-image",
+      "packageType": "Image",
+      "useCaseName": "Hello World Example"
+    }
+  ],
   "nodejs14.x": [
     {
       "directory": "nodejs14.x/cookiecutter-aws-sam-hello-nodejs",


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
