### PR TITLE
fix: fix manifest-v2.json file and add GH action to validate this from now on

### DIFF
--- a/.github/workflows/manifest-v2-check.yml
+++ b/.github/workflows/manifest-v2-check.yml
@@ -13,5 +13,4 @@ jobs:
         uses: actions/checkout@v3
       - name: Validate manifest-v2.json
         run: |
-          ls -ltra
           cat manifest-v2.json | jq

--- a/.github/workflows/manifest-v2-check.yml
+++ b/.github/workflows/manifest-v2-check.yml
@@ -1,0 +1,14 @@
+name: "Check if Manifest v2 is a valid JSON"
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  check-if-manifestv2-is-valid-json:
+    permissions:
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate manifest-v2.json
+        run: |
+          echo manifest-v2.json | jq

--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -98,6 +98,7 @@
       "packageType": "Zip",
       "useCaseName": "Scheduled task"
     },
+    {
       "directory": "dotnet6/cookiecutter-aws-sam-quick-start-from-scratch-dotnet",
       "displayName": "Quick Start: From Scratch",
       "dependencyManager": "cli-package",

--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -16,6 +16,7 @@
       "packageType": "Zip",
       "useCaseName": "Multi-step workflow"
     },
+    {
       "directory": "dotnetcore3.1/cookiecutter-aws-sam-quick-start-web-dotnet",
       "displayName": "Quick Start: Web Backend",
       "dependencyManager": "cli-package",

--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -16,7 +16,6 @@
       "packageType": "Zip",
       "useCaseName": "Multi-step workflow"
     },
-    {
       "directory": "dotnetcore3.1/cookiecutter-aws-sam-quick-start-web-dotnet",
       "displayName": "Quick Start: Web Backend",
       "dependencyManager": "cli-package",


### PR DESCRIPTION
*Issue #, if available:*
Earlier PR have changed manifest-v2.json file which then affected SAM CLI by failing to parse it. 

*Description of changes:*
This PR is addressing that issue as well as adding a GH action to validate this forward.

Invalid manifest run: https://github.com/mndeveci/aws-sam-cli-app-templates/runs/6397633007?check_suite_focus=true
Valid manifest run: https://github.com/mndeveci/aws-sam-cli-app-templates/runs/6397687402?check_suite_focus=true


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
