### PR TITLE
feat: improve new PR and issue labeling for triaging

### DIFF
--- a/.github/ISSUE_TEMPLATE/anything_else.md
+++ b/.github/ISSUE_TEMPLATE/anything_else.md
@@ -1,0 +1,8 @@
+---
+name: Anything else
+about: Choose if your issue doesn't apply to the other templates
+title: ''
+labels: ['stage/needs-triage']
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create an issue to report a bug for AWS SAM CLI Application Templates
+title: "Bug: TITLE"
+labels: ['type/bug', 'stage/needs-triage']
+assignees: ''
+
+---
+
+<!-- Make sure we don't have an existing Issue that reports the bug you are seeing (both open and closed). 
+If you do find an existing Issue, re-open or add a comment to that Issue instead of creating a new one. -->
+
+### Description:
+<!-- Briefly describe the bug you are facing.-->
+
+
+
+### Steps to reproduce:
+<!-- Provide detailed steps to replicate the bug, including steps from third party tools (CDK, etc.) -->
+
+
+
+### Observed result:
+<!-- Please provide command output with `--debug` flag set.-->
+
+
+
+### Expected result:
+<!-- Describe what you expected.-->
+
+
+
+### Additional environment details (Ex: Windows, Mac, Amazon Linux etc)
+
+1. OS:
+2. If using SAM CLI, `sam --version`:
+3. AWS region:
+
+`Add --debug flag to any SAM CLI commands you are running`

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea/feature/enhancement for AWS SAM CLI Application Templates
+title: "Feature request: TITLE"
+labels: ['type/feature', 'stage/needs-triage']
+assignees: ''
+
+---
+
+<!-- Make sure we don't have an existing Issue for that feature request (open or closed). -->
+
+### Describe your idea/feature/enhancement
+
+Provide a clear description.
+
+Ex: I wish AWS SAM CLI Application Templates would [...]
+
+### Proposal
+
+Add details on how to add this to the product.
+
+### Additional Details

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,5 +1,5 @@
 ---
-name: Anything else
+name: Other
 about: Choose if your issue doesn't apply to the other templates
 title: ''
 labels: ['stage/needs-triage']

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -26,6 +26,6 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                labels: ['pr/external']
+                labels: ['pr/external', 'stage/needs-triage']
               })
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Will help triage which new issues and PRs haven't been looked at by the team, as querying by no comments or no labels can sometimes be misleading.
New label stage/needs-triage automatically assigned on new issues and PRs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
