### PR TITLE
Simplify template for Rust projects.

### DIFF
--- a/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/Makefile
+++ b/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/Makefile
@@ -1,20 +1,9 @@
 {% if cookiecutter.architecture == 'arm64' -%}
-ARCH = aarch64-unknown-linux-gnu
+CARGO_LAMBDA_FLAGS = '--arm64'
 {%- else -%}
-ARCH = x86_64-unknown-linux-gnu
+CARGO_LAMBDA_FLAGS = ''
 {%- endif %}
-ARCH_SPLIT = $(subst -, ,$(ARCH))
 
 .PHONY: build
 build:
-ifeq ("$(shell zig targets | jq -r .native.cpu.arch)-$(shell zig targets | jq -r .native.os)-$(shell zig targets | jq -r .native.abi)", "$(word 1,$(ARCH_SPLIT))-$(word 3,$(ARCH_SPLIT))-$(word 4,$(ARCH_SPLIT))")
-	@echo "Same host and target. Using native build"
-	cargo build --release --target $(ARCH)
-else
-	@echo "Different host and target. Using zigbuild"
-	cargo zigbuild --release --target $(ARCH)
-endif
-
-	rm -rf ./build
-	mkdir -p ./build
-	cp -v ./target/$(ARCH)/release/{{ cookiecutter.project_slug }} ./build/bootstrap
+	cargo lambda build --release $(CARGO_LAMBDA_FLAGS)

--- a/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/README.md
+++ b/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/README.md
@@ -30,8 +30,7 @@ To deploy the application, you need the folllowing tools:
 * SAM CLI - [Install the SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 * [Rust](https://www.rust-lang.org/) version 1.56.0 or newer
-* [cargo-zigbuild](https://github.com/messense/cargo-zigbuild) and [Zig](https://ziglang.org/) for cross-compilation
-* [jq](https://stedolan.github.io/jq/) for tooling specific to this project
+* [cargo-lambda](https://github.com/cargo-lambda/cargo-lambda#installation) for cross-compilation
 
 To build and deploy your application for the first time, run the following in your shell:
 

--- a/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/template.yaml
+++ b/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/template.yaml
@@ -21,7 +21,7 @@ Resources:
   PutFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
-      CodeUri: build/
+      CodeUri: target/lambda/{{ cookiecutter.project_slug }}/
       Handler: bootstrap.is.the.handler
       Runtime: provided.al2
       Architectures:


### PR DESCRIPTION
- Use cargo-lambda to remove the boilerplate around cross-compilation.

Signed-off-by: David Calavera <david.calavera@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
