### PR TITLE
Bump maven version in Graavlm Maven dockerfile from 3.8.5 to 3.8.6

### DIFF
--- a/provided.al2/graalvm/java11/cookiecutter-aws-sam-graalvm-maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/provided.al2/graalvm/java11/cookiecutter-aws-sam-graalvm-maven/{{cookiecutter.project_name}}/Dockerfile
@@ -16,7 +16,7 @@ RUN mv $GRAAL_FOLDERNAME /usr/lib/graalvm
 RUN rm -rf $GRAAL_FOLDERNAME
 
 # Maven
-ENV MVN_VERSION 3.8.5
+ENV MVN_VERSION 3.8.6
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz

--- a/provided.al2/graalvm/java17/cookiecutter-aws-sam-graalvm-maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/provided.al2/graalvm/java17/cookiecutter-aws-sam-graalvm-maven/{{cookiecutter.project_name}}/Dockerfile
@@ -17,7 +17,7 @@ RUN rm -rf $GRAAL_FOLDERNAME
 
 
 # Maven
-ENV MVN_VERSION 3.8.5
+ENV MVN_VERSION 3.8.6
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz


### PR DESCRIPTION
*Issue #, if available:*
`https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME}` is now 404 for `3.8.5`. As shown in https://dlcdn.apache.org/maven/maven-3/, only `3.8.6` is available. 

Example of error:
```
----------------------------- Captured stderr call -----------------------------
Temporary directory /tmp/tmpgw_dpx4t created
['sam', 'init', '--no-input', '--location', PosixPath('/codebuild/output/src339179747/src/github.com/aws/aws-sam-cli-app-templates/provided.al2/graalvm/java17/cookiecutter-aws-sam-graalvm-maven'), '--name', 'project']
PATH=/root/.pyenv/versions/3.9.12/bin:/root/.pyenv/libexec:/root/.pyenv/plugins/python-build/bin:/root/.pyenv/plugins/pyenv-virtualenv/bin:/root/.pyenv/plugins/pyenv-update/bin:/root/.pyenv/plugins/pyenv-installer/bin:/root/.pyenv/plugins/pyenv-doctor/bin:/usr/local/bin/sbt/bin:/root/.goenv/shims:/root/.goenv/bin:/go/bin:/root/.phpenv/shims:/root/.phpenv/bin:/root/.pyenv/shims:/root/.pyenv/bin:/root/.rbenv/shims:/usr/local/rbenv/bin:/usr/local/rbenv/shims:/root/.dotnet/:/root/.dotnet/tools/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/tools:/usr/local/android-sdk-linux/tools:/usr/local/android-sdk-linux/tools/bin:/usr/local/android-sdk-linux/platform-tools:/codebuild/user/bin
Stdout: 
Stderr: 
['docker', 'build', '-t', 'al2-graalvm:java17-maven', '.']
PATH=/root/.pyenv/versions/3.9.12/bin:/root/.pyenv/libexec:/root/.pyenv/plugins/python-build/bin:/root/.pyenv/plugins/pyenv-virtualenv/bin:/root/.pyenv/plugins/pyenv-update/bin:/root/.pyenv/plugins/pyenv-installer/bin:/root/.pyenv/plugins/pyenv-doctor/bin:/usr/local/bin/sbt/bin:/root/.goenv/shims:/root/.goenv/bin:/go/bin:/root/.phpenv/shims:/root/.phpenv/bin:/root/.pyenv/shims:/root/.pyenv/bin:/root/.rbenv/shims:/usr/local/rbenv/bin:/usr/local/rbenv/shims:/root/.dotnet/:/root/.dotnet/tools/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/tools:/usr/local/android-sdk-linux/tools:/usr/local/android-sdk-linux/tools/bin:/usr/local/android-sdk-linux/platform-tools:/codebuild/user/bin
Stdout: Sending build context to Docker daemon  53.25kB

Step 1/26 : FROM public.ecr.aws/amazonlinux/amazonlinux:2
 ---> a169114ec907
Step 2/26 : RUN yum -y update     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran     less libcurl-devel openssl openssl-devel readline-devel xz-devel     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static     && rm -rf /var/cache/yum
 ---> Using cache
 ---> a9996c8325fb
Step 3/26 : ENV JAVA_VERSION java17
 ---> Using cache
 ---> f2dc3fab0c2a
Step 4/26 : ENV GRAAL_VERSION 22.1.0
 ---> Using cache
 ---> 8f6fa6ae654c
Step 5/26 : ENV GRAAL_FOLDERNAME graalvm-ce-${JAVA_VERSION}-${GRAAL_VERSION}
 ---> Using cache
 ---> fcd45118dfa2
Step 6/26 : ENV GRAAL_FILENAME graalvm-ce-${JAVA_VERSION}-linux-amd64-${GRAAL_VERSION}.tar.gz
 ---> Using cache
 ---> a732eb15a3a2
Step 7/26 : RUN curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAAL_VERSION}/${GRAAL_FILENAME} | tar -xvz
 ---> Using cache
 ---> bb86decce0ab
Step 8/26 : RUN mv $GRAAL_FOLDERNAME /usr/lib/graalvm
 ---> Using cache
 ---> 81bef2492817
Step 9/26 : RUN rm -rf $GRAAL_FOLDERNAME
 ---> Using cache
 ---> 39d251c38fc9
Step 10/26 : ENV MVN_VERSION 3.8.5
 ---> Using cache
 ---> c1e6b7929bfa
Step 11/26 : ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ---> Using cache
 ---> 09008b811f6d
Step 12/26 : ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 ---> Using cache
 ---> 128ce565f654
Step 13/26 : RUN curl -4 -L https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz
 ---> Running in fc8a0914de4b
[91m  % Total    % Received % Xferd  Average Speed   Time[0m[91m    Time     Time  Current
             [0m[91m      [0m[91m     [0m[91m   [0m[91m  [0m[91m    D[0m[91mlo[0m[91mad  Upload[0m[91m   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 -[0m[91m-:--:-- --:--:-- -[0m[91m-:--:--     0[0m[91m
100   196  100   196    0     0   3563      0 --:--:-- --:--:--[0m[91m --:--:--  3629
[0m[91m
gzip: stdin: not in gzip format
[0m[91mtar: Child returned status 1
tar: Error is not recoverable: exiting now
[0m
Stderr: The command '/bin/sh -c curl -4 -L https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz' returned a non-zero code: 2

Clean up temporary directory /tmp/tmpgw_dpx4t
```

*Description of changes:*
Bumping maven version from 3.8.5 to 3.8.6 to fix all failing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
