### PR TITLE
Update all cookiecutter.json files to add _copy_without_render

### DIFF
--- a/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/cookiecutter.json
+++ b/dotnet5.0-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "dotnet5.0"
+    "runtime": "dotnet5.0",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/cookiecutter.json
+++ b/dotnetcore3.1-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "dotnetcore3.1",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/cookiecutter.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-dotnet/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "dotnetcore3.1",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-powershell/cookiecutter.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-powershell/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "dotnetcore3.1",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/cookiecutter.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-hello-step-functions-sample-app/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "dotnetcore3.1",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs12.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/cookiecutter.json
+++ b/nodejs12.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs12.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs12.x/cookiecutter-aws-sam-hello-nodejs/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-aws-sam-hello-nodejs/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs12.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs12.x/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs12.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs12.x/cookiecutter-quick-start-cloudwatch-events/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-quick-start-cloudwatch-events/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs12.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs12.x/cookiecutter-quick-start-from-scratch/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-quick-start-from-scratch/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs12.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs12.x/cookiecutter-quick-start-s3/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-quick-start-s3/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs12.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs12.x/cookiecutter-quick-start-sns/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-quick-start-sns/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs12.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs12.x/cookiecutter-quick-start-sqs/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-quick-start-sqs/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs12.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs12.x/cookiecutter-quick-start-web/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-quick-start-web/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs12.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs12.x/cookiecutter-typescript-app-template/cookiecutter.json
+++ b/nodejs12.x/cookiecutter-typescript-app-template/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs12.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs14.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/cookiecutter.json
+++ b/nodejs14.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs14.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs14.x/cookiecutter-aws-sam-hello-nodejs/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-aws-sam-hello-nodejs/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs14.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs14.x/cookiecutter-aws-sam-hello-typescript-nodejs/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-aws-sam-hello-typescript-nodejs/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs14.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs14.x/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs14.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs14.x/cookiecutter-quick-start-cloudwatch-events/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-quick-start-cloudwatch-events/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs14.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs14.x/cookiecutter-quick-start-from-scratch/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-quick-start-from-scratch/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs14.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs14.x/cookiecutter-quick-start-s3/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-quick-start-s3/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs14.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs14.x/cookiecutter-quick-start-sns/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-quick-start-sns/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs14.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs14.x/cookiecutter-quick-start-sqs/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-quick-start-sqs/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs14.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs14.x/cookiecutter-quick-start-web/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-quick-start-web/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs14.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs16.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/cookiecutter.json
+++ b/nodejs16.x-image/cookiecutter-aws-sam-hello-nodejs-lambda-image/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs16.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs16.x/cookiecutter-aws-sam-hello-nodejs/cookiecutter.json
+++ b/nodejs16.x/cookiecutter-aws-sam-hello-nodejs/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs16.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs16.x/cookiecutter-aws-sam-hello-typescript-nodejs/cookiecutter.json
+++ b/nodejs16.x/cookiecutter-aws-sam-hello-typescript-nodejs/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs16.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs16.x/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/nodejs16.x/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs16.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs16.x/cookiecutter-quick-start-cloudwatch-events/cookiecutter.json
+++ b/nodejs16.x/cookiecutter-quick-start-cloudwatch-events/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs16.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs16.x/cookiecutter-quick-start-from-scratch/cookiecutter.json
+++ b/nodejs16.x/cookiecutter-quick-start-from-scratch/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs16.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs16.x/cookiecutter-quick-start-s3/cookiecutter.json
+++ b/nodejs16.x/cookiecutter-quick-start-s3/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs16.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs16.x/cookiecutter-quick-start-sns/cookiecutter.json
+++ b/nodejs16.x/cookiecutter-quick-start-sns/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs16.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs16.x/cookiecutter-quick-start-sqs/cookiecutter.json
+++ b/nodejs16.x/cookiecutter-quick-start-sqs/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs16.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs16.x/cookiecutter-quick-start-web/cookiecutter.json
+++ b/nodejs16.x/cookiecutter-quick-start-web/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "nodejs16.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.6-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
+++ b/python3.6-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "python3.6"
+    "runtime": "python3.6",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.6/cookiecutter-aws-sam-hello-python/cookiecutter.json
+++ b/python3.6/cookiecutter-aws-sam-hello-python/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "python3.6"
+    "runtime": "python3.6",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.6/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/python3.6/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "python3.6"
+    "runtime": "python3.6",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.7-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
+++ b/python3.7-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "python3.7"
+    "runtime": "python3.7",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.7/cookiecutter-aws-sam-hello-python/cookiecutter.json
+++ b/python3.7/cookiecutter-aws-sam-hello-python/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "python3.7"
+    "runtime": "python3.7",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.7/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/python3.7/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "python3.7"
+    "runtime": "python3.7",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.8/cookiecutter-aws-sam-efs-python/cookiecutter.json
+++ b/python3.8/cookiecutter-aws-sam-efs-python/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "python3.8",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.8/cookiecutter-aws-sam-hello-python/cookiecutter.json
+++ b/python3.8/cookiecutter-aws-sam-hello-python/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "python3.8",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.8/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/python3.8/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "python3.8",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/ruby2.7-image/cookiecutter-aws-sam-hello-ruby-lambda-image/cookiecutter.json
+++ b/ruby2.7-image/cookiecutter-aws-sam-hello-ruby-lambda-image/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "ruby2.7",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/ruby2.7/cookiecutter-aws-sam-hello-ruby/cookiecutter.json
+++ b/ruby2.7/cookiecutter-aws-sam-hello-ruby/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "ruby2.7",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/ruby2.7/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/ruby2.7/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "ruby2.7",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }


### PR DESCRIPTION
*Issue #, if available:*
The newline handling logic introduced in cookiecutter v2+ broke SAM CLI as we tried to bump it in lieu of a CVE in cookiecutter (See [SAM CLI PR](https://github.com/aws/aws-sam-cli/pull/3956)). The particular file breaking cookiecutter is `.gitignore`, in which Python detects multiple linebreak characters, instead of single.

We need to fix this so we can bump the cookiecutter version in SAM CLI.


*Description of changes:*
As the `.gitignore` files don't really need to be rendered by cookiecutter, we add the `_copy_without_render` config into the `cookiecutter.json` files, so cookiecutter in SAM CLI will skip rendering the `.gitignore` files.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
