### PR TITLE
Rename Python 3.8 and 3.9 EFS example

### DIFF
--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -740,7 +740,7 @@
       "dependencyManager": "pip",
       "appTemplate": "efs-sample-app",
       "packageType": "Zip",
-      "useCaseName": "Serverless API"
+      "useCaseName": "Lambda EFS example"
     }
   ],
   "python3.9": [
@@ -783,7 +783,7 @@
       "dependencyManager": "pip",
       "appTemplate": "efs-sample-app",
       "packageType": "Zip",
-      "useCaseName": "Serverless API"
+      "useCaseName": "Lambda EFS example"
     }
   ],
   "ruby2.7": [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the Python 3.8 and Python 3.9 examples, the EFS example is incorrectly named as 'Serverless API'. I've updated the name of these two examples to 'Lambda EFS example' in the manifest file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
