### PR TITLE
docs: Improve "dotnet quick start web" comment

### DIFF
--- a/dotnet6/cookiecutter-aws-sam-quick-start-web-dotnet/{{cookiecutter.project_name}}/src/{{cookiecutter.project_name}}/Program.cs
+++ b/dotnet6/cookiecutter-aws-sam-quick-start-web-dotnet/{{cookiecutter.project_name}}/src/{{cookiecutter.project_name}}/Program.cs
@@ -26,8 +26,8 @@ builder.Services
         .AddScoped<IDynamoDBContext, DynamoDBContext>()
         .AddScoped<IBookRepository, BookRepository>();
 
-// Add AWS Lambda support. When application is run in Lambda Kestrel is swapped out as the web server with Amazon.Lambda.AspNetCoreServer. This
-// package will act as the webserver translating request and responses between the Lambda event source and ASP.NET Core.
+// Add AWS Lambda support. When running the application as an AWS Serverless application, Kestrel is replaced
+// with a Lambda function contained in the Amazon.Lambda.AspNetCoreServer package, which marshals the request into the ASP.NET Core hosting framework.
 builder.Services.AddAWSLambdaHosting(LambdaEventSource.HttpApi);
 
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Update a template comment. Previously a comma between "Lambda" and "Kestrel" would've helped with readability. New wording borrowed from [an AWS blog post](https://aws.amazon.com/blogs/developer/running-serverless-asp-net-core-web-apis-with-amazon-lambda/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
