### PR TITLE
fix function iam role attribute name for python 3.8/9 ml templates

### DIFF
--- a/python3.8-image/cookiecutter-ml-apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.8-image/cookiecutter-ml-apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
@@ -45,4 +45,4 @@ Outputs:
     Value: !GetAtt InferenceFunction.Arn
   InferenceFunctionIamRole:
     Description: "Implicit IAM Role created for Inference function"
-    Value: !GetAtt InferenceFunction.Arn
+    Value: !GetAtt InferenceFunctionRole.Arn

--- a/python3.8-image/cookiecutter-ml-apigw-scikit-learn/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.8-image/cookiecutter-ml-apigw-scikit-learn/{{cookiecutter.project_name}}/template.yaml
@@ -45,4 +45,4 @@ Outputs:
     Value: !GetAtt InferenceFunction.Arn
   InferenceFunctionIamRole:
     Description: "Implicit IAM Role created for Inference function"
-    Value: !GetAtt InferenceFunction.Arn
+    Value: !GetAtt InferenceFunctionRole.Arn

--- a/python3.8-image/cookiecutter-ml-apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.8-image/cookiecutter-ml-apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
@@ -45,4 +45,4 @@ Outputs:
     Value: !GetAtt InferenceFunction.Arn
   InferenceFunctionIamRole:
     Description: "Implicit IAM Role created for Inference function"
-    Value: !GetAtt InferenceFunction.Arn
+    Value: !GetAtt InferenceFunctionRole.Arn

--- a/python3.8-image/cookiecutter-ml-apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.8-image/cookiecutter-ml-apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
@@ -45,4 +45,4 @@ Outputs:
     Value: !GetAtt InferenceFunction.Arn
   InferenceFunctionIamRole:
     Description: "Implicit IAM Role created for Inference function"
-    Value: !GetAtt InferenceFunction.Arn
+    Value: !GetAtt InferenceFunctionRole.Arn

--- a/python3.9-image/cookiecutter-ml-apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.9-image/cookiecutter-ml-apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
@@ -45,4 +45,4 @@ Outputs:
     Value: !GetAtt InferenceFunction.Arn
   InferenceFunctionIamRole:
     Description: "Implicit IAM Role created for Inference function"
-    Value: !GetAtt InferenceFunction.Arn
+    Value: !GetAtt InferenceFunctionRole.Arn

--- a/python3.9-image/cookiecutter-ml-apigw-scikit-learn/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.9-image/cookiecutter-ml-apigw-scikit-learn/{{cookiecutter.project_name}}/template.yaml
@@ -45,4 +45,4 @@ Outputs:
     Value: !GetAtt InferenceFunction.Arn
   InferenceFunctionIamRole:
     Description: "Implicit IAM Role created for Inference function"
-    Value: !GetAtt InferenceFunction.Arn
+    Value: !GetAtt InferenceFunctionRole.Arn

--- a/python3.9-image/cookiecutter-ml-apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.9-image/cookiecutter-ml-apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
@@ -45,4 +45,4 @@ Outputs:
     Value: !GetAtt InferenceFunction.Arn
   InferenceFunctionIamRole:
     Description: "Implicit IAM Role created for Inference function"
-    Value: !GetAtt InferenceFunction.Arn
+    Value: !GetAtt InferenceFunctionRole.Arn

--- a/python3.9-image/cookiecutter-ml-apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.9-image/cookiecutter-ml-apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
@@ -45,4 +45,4 @@ Outputs:
     Value: !GetAtt InferenceFunction.Arn
   InferenceFunctionIamRole:
     Description: "Implicit IAM Role created for Inference function"
-    Value: !GetAtt InferenceFunction.Arn
+    Value: !GetAtt InferenceFunctionRole.Arn


### PR DESCRIPTION
Looks like the attribute name for the deployed iam role resource is wrong on the python 3.8/3.9 ml cookiecutter templates. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
