### PR TITLE
fix: add `_copy_wihout_render` to all cookiecutter.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.pyc
 __pycache__
 .idea/
+.python-version
 venv/
 .env/

--- a/dotnet6-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/cookiecutter.json
+++ b/dotnet6-image/cookiecutter-aws-sam-hello-dotnet-lambda-image/cookiecutter.json
@@ -1,4 +1,8 @@
 {
     "project_name": "Name of the project",
-    "runtime": "dotnet6.0"
+    "runtime": "dotnet6.0",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/dotnet6/cookiecutter-aws-sam-hello-dotnet/cookiecutter.json
+++ b/dotnet6/cookiecutter-aws-sam-hello-dotnet/cookiecutter.json
@@ -5,5 +5,9 @@
         "value": [
             "x86_64", "arm64"
         ]
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/dotnet6/cookiecutter-aws-sam-hello-powershell/cookiecutter.json
+++ b/dotnet6/cookiecutter-aws-sam-hello-powershell/cookiecutter.json
@@ -5,5 +5,9 @@
         "value": [
             "x86_64", "arm64"
         ]
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/dotnet6/cookiecutter-aws-sam-hello-step-functions-sample-app/cookiecutter.json
+++ b/dotnet6/cookiecutter-aws-sam-hello-step-functions-sample-app/cookiecutter.json
@@ -5,5 +5,9 @@
         "value": [
             "x86_64", "arm64"
         ]
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/dotnet6/cookiecutter-aws-sam-quick-start-cloudwatch-events-dotnet/cookiecutter.json
+++ b/dotnet6/cookiecutter-aws-sam-quick-start-cloudwatch-events-dotnet/cookiecutter.json
@@ -5,5 +5,9 @@
         "value": [
             "x86_64", "arm64"
         ]
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/dotnet6/cookiecutter-aws-sam-quick-start-from-scratch-dotnet/cookiecutter.json
+++ b/dotnet6/cookiecutter-aws-sam-quick-start-from-scratch-dotnet/cookiecutter.json
@@ -5,5 +5,9 @@
         "value": [
             "x86_64", "arm64"
         ]
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/dotnet6/cookiecutter-aws-sam-quick-start-sqs-dotnet/cookiecutter.json
+++ b/dotnet6/cookiecutter-aws-sam-quick-start-sqs-dotnet/cookiecutter.json
@@ -5,5 +5,9 @@
         "value": [
             "x86_64", "arm64"
         ]
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/dotnet6/cookiecutter-aws-sam-quick-start-web-dotnet/cookiecutter.json
+++ b/dotnet6/cookiecutter-aws-sam-quick-start-web-dotnet/cookiecutter.json
@@ -1,3 +1,7 @@
 {
-    "project_name": "Name of the project"
+    "project_name": "Name of the project",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/dotnet6/cookiecutter-aws-sam-quickstart-sns-dotnet/cookiecutter.json
+++ b/dotnet6/cookiecutter-aws-sam-quickstart-sns-dotnet/cookiecutter.json
@@ -5,5 +5,9 @@
         "value": [
             "x86_64", "arm64"
         ]
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/dotnetcore3.1/cookiecutter-aws-sam-quick-start-cloudwatch-events-dotnet/cookiecutter.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-quick-start-cloudwatch-events-dotnet/cookiecutter.json
@@ -1,4 +1,8 @@
 {
     "project_name": "Name of the project",
-    "runtime": "dotnetcore3.1"
+    "runtime": "dotnetcore3.1",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/dotnetcore3.1/cookiecutter-aws-sam-quick-start-from-scratch-dotnet/cookiecutter.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-quick-start-from-scratch-dotnet/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "dotnetcore3.1"
+    "runtime": "dotnetcore3.1",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/dotnetcore3.1/cookiecutter-aws-sam-quick-start-s3-dotnet/cookiecutter.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-quick-start-s3-dotnet/cookiecutter.json
@@ -1,4 +1,8 @@
 {
     "project_name": "Name of the project",
-    "runtime": "dotnetcore3.1"
+    "runtime": "dotnetcore3.1",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/dotnetcore3.1/cookiecutter-aws-sam-quick-start-sns-dotnet/cookiecutter.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-quick-start-sns-dotnet/cookiecutter.json
@@ -1,4 +1,8 @@
 {
     "project_name": "Name of the project",
-    "runtime": "dotnetcore3.1"
+    "runtime": "dotnetcore3.1",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/dotnetcore3.1/cookiecutter-aws-sam-quick-start-sqs-dotnet/cookiecutter.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-quick-start-sqs-dotnet/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "dotnetcore3.1"
+    "runtime": "dotnetcore3.1",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/dotnetcore3.1/cookiecutter-aws-sam-quick-start-web-dotnet/cookiecutter.json
+++ b/dotnetcore3.1/cookiecutter-aws-sam-quick-start-web-dotnet/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "dotnetcore3.1"
+    "runtime": "dotnetcore3.1",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/go1.x-image/cookiecutter-aws-sam-hello-golang-lambda-image/cookiecutter.json
+++ b/go1.x-image/cookiecutter-aws-sam-hello-golang-lambda-image/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "go1.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/go1.x/cookiecutter-aws-sam-eventbridge-hello-golang/cookiecutter.json
+++ b/go1.x/cookiecutter-aws-sam-eventbridge-hello-golang/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "go1.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/go1.x/cookiecutter-aws-sam-eventbridge-schema-app-golang/cookiecutter.json
+++ b/go1.x/cookiecutter-aws-sam-eventbridge-schema-app-golang/cookiecutter.json
@@ -11,5 +11,8 @@
     "AWS_Schema_source": "aws.ec2",
     "AWS_Schema_detail_type": "EC2 Instance State-change Notification",
     "codegen_path": "{{ cookiecutter.project_name }}/{{ cookiecutter.function_name }}/{{ cookiecutter.AWS_Schema_root|lower|replace('.', '/') }}",
-    "codegen_package_name": "{{ cookiecutter.AWS_Schema_root.lower()[cookiecutter.AWS_Schema_root.rfind(\".\")+1:] }}"
+    "codegen_package_name": "{{ cookiecutter.AWS_Schema_root.lower()[cookiecutter.AWS_Schema_root.rfind(\".\")+1:] }}",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/go1.x/cookiecutter-aws-sam-hello-golang/cookiecutter.json
+++ b/go1.x/cookiecutter-aws-sam-hello-golang/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "go1.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/go1.x/cookiecutter-aws-sam-hello-step-functions-sample-app/cookiecutter.json
+++ b/go1.x/cookiecutter-aws-sam-hello-step-functions-sample-app/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "go1.x",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java11-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/cookiecutter.json
+++ b/java11-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/cookiecutter.json
@@ -3,5 +3,9 @@
     "runtime": "java11",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/java11-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/cookiecutter.json
+++ b/java11-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/cookiecutter.json
@@ -3,5 +3,9 @@
     "runtime": "java11",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/java11/cookiecutter-aws-sam-eventbridge-hello-java-gradle/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-eventbridge-hello-java-gradle/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java11",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java11/cookiecutter-aws-sam-eventbridge-hello-java-maven/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-eventbridge-hello-java-maven/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java11",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/cookiecutter.json
@@ -9,5 +9,8 @@
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",
     "AWS_Schema_root": "aws.ec2.EC2InstanceStateChangeNotification",
     "AWS_Schema_source": "aws.ec2",
-    "AWS_Schema_detail_type": "EC2 Instance State-change Notification"
+    "AWS_Schema_detail_type": "EC2 Instance State-change Notification",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/cookiecutter.json
@@ -9,5 +9,8 @@
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",
     "AWS_Schema_root": "aws.ec2.EC2InstanceStateChangeNotification",
     "AWS_Schema_source": "aws.ec2",
-    "AWS_Schema_detail_type": "EC2 Instance State-change Notification"
+    "AWS_Schema_detail_type": "EC2 Instance State-change Notification",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java11/cookiecutter-aws-sam-hello-java-gradle/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-hello-java-gradle/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java11",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java11/cookiecutter-aws-sam-hello-java-maven/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-hello-java-maven/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java11",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java11/cookiecutter-aws-sam-step-functions-sample-app-gradle/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-step-functions-sample-app-gradle/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java11",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java11/cookiecutter-aws-sam-step-functions-sample-app-maven/cookiecutter.json
+++ b/java11/cookiecutter-aws-sam-step-functions-sample-app-maven/cookiecutter.json
@@ -3,5 +3,9 @@
     "runtime": "java11",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/cookiecutter.json
+++ b/java8-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "java8"
+    "runtime": "java8",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/cookiecutter.json
+++ b/java8-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "java8"
+    "runtime": "java8",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8.al2-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/cookiecutter.json
+++ b/java8.al2-image/cookiecutter-aws-sam-hello-java-gradle-lambda-image/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java8.al2",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8.al2-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/cookiecutter.json
+++ b/java8.al2-image/cookiecutter-aws-sam-hello-java-maven-lambda-image/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java8.al2",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-gradle/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-gradle/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java8.al2",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-maven/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-hello-java-maven/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java8.al2",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/cookiecutter.json
@@ -9,5 +9,8 @@
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",
     "AWS_Schema_root": "aws.ec2.EC2InstanceStateChangeNotification",
     "AWS_Schema_source": "aws.ec2",
-    "AWS_Schema_detail_type": "EC2 Instance State-change Notification"
+    "AWS_Schema_detail_type": "EC2 Instance State-change Notification",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/cookiecutter.json
@@ -9,5 +9,8 @@
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",
     "AWS_Schema_root": "aws.ec2.EC2InstanceStateChangeNotification",
     "AWS_Schema_source": "aws.ec2",
-    "AWS_Schema_detail_type": "EC2 Instance State-change Notification"
+    "AWS_Schema_detail_type": "EC2 Instance State-change Notification",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8.al2/cookiecutter-aws-sam-hello-java-gradle/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-hello-java-gradle/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java8.al2",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8.al2/cookiecutter-aws-sam-hello-java-maven/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-hello-java-maven/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java8.al2",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-gradle/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-gradle/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java8.al2",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-maven/cookiecutter.json
+++ b/java8.al2/cookiecutter-aws-sam-step-functions-sample-app-maven/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "java8.al2",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8/cookiecutter-aws-sam-eventbridge-hello-java-gradle/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-eventbridge-hello-java-gradle/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Your EventBridge Starter app",
-    "runtime": "java8"
+    "runtime": "java8",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8/cookiecutter-aws-sam-eventbridge-hello-java-maven/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-eventbridge-hello-java-maven/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Your EventBridge Starter app",
-    "runtime": "java8"
+    "runtime": "java8",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-gradle/cookiecutter.json
@@ -6,5 +6,9 @@
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",
     "AWS_Schema_root": "aws.ec2.EC2InstanceStateChangeNotification",
     "AWS_Schema_source": "aws.ec2",
-    "AWS_Schema_detail_type": "EC2 Instance State-change Notification"
+    "AWS_Schema_detail_type": "EC2 Instance State-change Notification",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven/cookiecutter.json
@@ -6,5 +6,8 @@
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",
     "AWS_Schema_root": "aws.ec2.EC2InstanceStateChangeNotification",
     "AWS_Schema_source": "aws.ec2",
-    "AWS_Schema_detail_type": "EC2 Instance State-change Notification"
+    "AWS_Schema_detail_type": "EC2 Instance State-change Notification",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8/cookiecutter-aws-sam-hello-java-gradle/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-hello-java-gradle/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "java8"
+    "runtime": "java8",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8/cookiecutter-aws-sam-hello-java-maven/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-hello-java-maven/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "java8"
+    "runtime": "java8",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8/cookiecutter-aws-sam-step-functions-sample-app-gradle/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-step-functions-sample-app-gradle/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "java8"
+    "runtime": "java8",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/java8/cookiecutter-aws-sam-step-functions-sample-app-maven/cookiecutter.json
+++ b/java8/cookiecutter-aws-sam-step-functions-sample-app-maven/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "java8"
+    "runtime": "java8",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/nodejs14.x/cookiecutter-aws-sam-hello-powertools-typescript-nodejs/cookiecutter.json
+++ b/nodejs14.x/cookiecutter-aws-sam-hello-powertools-typescript-nodejs/cookiecutter.json
@@ -6,5 +6,9 @@
     },
     "Powertools X-Ray Tracing": ["enabled","disabled"],
     "Powertools Metrics": ["enabled","disabled"],
-    "Powertools Logging": ["enabled","disabled"]
+    "Powertools Logging": ["enabled","disabled"],
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/provided.al2/graalvm/java11/cookiecutter-aws-sam-graalvm-gradle/cookiecutter.json
+++ b/provided.al2/graalvm/java11/cookiecutter-aws-sam-graalvm-gradle/cookiecutter.json
@@ -2,5 +2,8 @@
     "project_name": "Name of the project",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/provided.al2/graalvm/java11/cookiecutter-aws-sam-graalvm-maven/cookiecutter.json
+++ b/provided.al2/graalvm/java11/cookiecutter-aws-sam-graalvm-maven/cookiecutter.json
@@ -2,5 +2,8 @@
     "project_name": "Name of the project",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/provided.al2/graalvm/java17/cookiecutter-aws-sam-graalvm-gradle/cookiecutter.json
+++ b/provided.al2/graalvm/java17/cookiecutter-aws-sam-graalvm-gradle/cookiecutter.json
@@ -2,5 +2,8 @@
     "project_name": "Name of the project",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/provided.al2/graalvm/java17/cookiecutter-aws-sam-graalvm-maven/cookiecutter.json
+++ b/provided.al2/graalvm/java17/cookiecutter-aws-sam-graalvm-maven/cookiecutter.json
@@ -2,5 +2,8 @@
     "project_name": "Name of the project",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/provided.al2/rust/cookiecutter-aws-sam-hello-rust/cookiecutter.json
+++ b/provided.al2/rust/cookiecutter-aws-sam-hello-rust/cookiecutter.json
@@ -1,5 +1,8 @@
 {
     "project_name": "My Project",
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
-    "architecture": ["x86_64", "arm64"]
+    "architecture": ["x86_64", "arm64"],
+    "_copy_without_render": [
+      ".gitignore"
+    ]
   }

--- a/python3.6/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
+++ b/python3.6/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
@@ -1,4 +1,8 @@
 {
     "project_name": "Name of the project",
-    "runtime": "python3.6"
+    "runtime": "python3.6",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
+
 }

--- a/python3.6/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
+++ b/python3.6/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
@@ -6,5 +6,8 @@
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",
     "AWS_Schema_root": "aws.ec2.EC2InstanceStateChangeNotification",
     "AWS_Schema_source": "aws.ec2",
-    "AWS_Schema_detail_type": "EC2 Instance State-change Notification"
+    "AWS_Schema_detail_type": "EC2 Instance State-change Notification",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.7/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
+++ b/python3.7/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "Name of the project",
-    "runtime": "python3.7"
+    "runtime": "python3.7",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.7/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
+++ b/python3.7/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
@@ -6,5 +6,8 @@
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",
     "AWS_Schema_root": "aws.ec2.EC2InstanceStateChangeNotification",
     "AWS_Schema_source": "aws.ec2",
-    "AWS_Schema_detail_type": "EC2 Instance State-change Notification"
+    "AWS_Schema_detail_type": "EC2 Instance State-change Notification",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.8-image/cookiecutter-ml-apigw-pytorch/cookiecutter.json
+++ b/python3.8-image/cookiecutter-ml-apigw-pytorch/cookiecutter.json
@@ -5,5 +5,8 @@
     "value": [
       "x86_64"
     ]
-  }
+  },
+  "_copy_without_render": [
+    ".gitignore"
+  ]
 }

--- a/python3.8-image/cookiecutter-ml-apigw-scikit-learn/cookiecutter.json
+++ b/python3.8-image/cookiecutter-ml-apigw-scikit-learn/cookiecutter.json
@@ -5,5 +5,8 @@
     "value": [
       "x86_64"
     ]
-  }
+  },
+  "_copy_without_render": [
+    ".gitignore"
+  ]
 }

--- a/python3.8-image/cookiecutter-ml-apigw-tensorflow/cookiecutter.json
+++ b/python3.8-image/cookiecutter-ml-apigw-tensorflow/cookiecutter.json
@@ -5,5 +5,8 @@
     "value": [
       "x86_64"
     ]
-  }
+  },
+  "_copy_without_render": [
+    ".gitignore"
+  ]
 }

--- a/python3.8-image/cookiecutter-ml-apigw-xgboost/cookiecutter.json
+++ b/python3.8-image/cookiecutter-ml-apigw-xgboost/cookiecutter.json
@@ -5,5 +5,8 @@
     "value": [
       "x86_64"
     ]
-  }
+  },
+  "_copy_without_render": [
+    ".gitignore"
+  ]
 }

--- a/python3.8/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
+++ b/python3.8/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "python3.8",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.8/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
+++ b/python3.8/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
@@ -9,5 +9,8 @@
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",
     "AWS_Schema_root": "aws.ec2.EC2InstanceStateChangeNotification",
     "AWS_Schema_source": "aws.ec2",
-    "AWS_Schema_detail_type": "EC2 Instance State-change Notification"
+    "AWS_Schema_detail_type": "EC2 Instance State-change Notification",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.9-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
+++ b/python3.9-image/cookiecutter-aws-sam-hello-python-lambda-image/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "python3.9",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.9-image/cookiecutter-ml-apigw-pytorch/cookiecutter.json
+++ b/python3.9-image/cookiecutter-ml-apigw-pytorch/cookiecutter.json
@@ -7,5 +7,8 @@
     "value": [
       "x86_64"
     ]
-  }
+  },
+  "_copy_without_render": [
+    ".gitignore"
+  ]
 }

--- a/python3.9-image/cookiecutter-ml-apigw-scikit-learn/cookiecutter.json
+++ b/python3.9-image/cookiecutter-ml-apigw-scikit-learn/cookiecutter.json
@@ -6,5 +6,8 @@
     "value": [
       "x86_64"
     ]
-  }
+  },
+  "_copy_without_render": [
+    ".gitignore"
+  ]
 }

--- a/python3.9-image/cookiecutter-ml-apigw-tensorflow/cookiecutter.json
+++ b/python3.9-image/cookiecutter-ml-apigw-tensorflow/cookiecutter.json
@@ -6,5 +6,8 @@
     "value": [
       "x86_64"
     ]
-  }
+  },
+  "_copy_without_render": [
+    ".gitignore"
+  ]
 }

--- a/python3.9-image/cookiecutter-ml-apigw-xgboost/cookiecutter.json
+++ b/python3.9-image/cookiecutter-ml-apigw-xgboost/cookiecutter.json
@@ -6,5 +6,8 @@
     "value": [
       "x86_64"
     ]
-  }
+  },
+  "_copy_without_render": [
+    ".gitignore"
+  ]
 }

--- a/python3.9/cookiecutter-aws-sam-efs-python/cookiecutter.json
+++ b/python3.9/cookiecutter-aws-sam-efs-python/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "python3.9",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.9/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
+++ b/python3.9/cookiecutter-aws-sam-eventBridge-python/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "python3.9",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.9/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
+++ b/python3.9/cookiecutter-aws-sam-eventbridge-schema-app-python/cookiecutter.json
@@ -9,5 +9,8 @@
     "AWS_Schema_name": "EC2InstanceStateChangeNotification",
     "AWS_Schema_root": "aws.ec2.EC2InstanceStateChangeNotification",
     "AWS_Schema_source": "aws.ec2",
-    "AWS_Schema_detail_type": "EC2 Instance State-change Notification"
+    "AWS_Schema_detail_type": "EC2 Instance State-change Notification",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.9/cookiecutter-aws-sam-hello-python/cookiecutter.json
+++ b/python3.9/cookiecutter-aws-sam-hello-python/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "python3.9",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.9/cookiecutter-aws-sam-step-functions-etl-python/cookiecutter.json
+++ b/python3.9/cookiecutter-aws-sam-step-functions-etl-python/cookiecutter.json
@@ -1,4 +1,7 @@
 {
     "project_name": "sample-glue-etl-project",
-    "runtime": "python3.9"
+    "runtime": "python3.9",
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }

--- a/python3.9/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
+++ b/python3.9/cookiecutter-aws-sam-step-functions-sample-app/cookiecutter.json
@@ -3,5 +3,8 @@
     "runtime": "python3.9",
     "architectures": {
         "value": []
-    }
+    },
+    "_copy_without_render": [
+        ".gitignore"
+    ]
 }


### PR DESCRIPTION
*Issue #, if available:*

This is an extension of https://github.com/aws/aws-sam-cli-app-templates/pull/258 to ensure that all cookiecutter.json files have `_copy_without_render` set.

*Description of changes:*

As the .gitignore files don't really need to be rendered by cookiecutter, we add the _copy_without_render config into the cookiecutter.json files, so cookiecutter in SAM CLI will skip rendering the .gitignore files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
