### PR TITLE
Add unknown type for try catch section in TypeScript templates

### DIFF
--- a/nodejs14.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/hello-world/app.ts
+++ b/nodejs14.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/hello-world/app.ts
@@ -19,12 +19,12 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
                 message: 'hello world',
             }),
         };
-    } catch (err) {
+    } catch (err: unknown) {
         console.log(err);
         response = {
             statusCode: 500,
             body: JSON.stringify({
-                message: 'some error happened',
+                message: err instanceof Error ? err.message : 'some error happened',
             }),
         };
     }

--- a/nodejs16.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/hello-world/app.ts
+++ b/nodejs16.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/hello-world/app.ts
@@ -19,12 +19,12 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
                 message: 'hello world',
             }),
         };
-    } catch (err) {
+    } catch (err: unknown) {
         console.log(err);
         response = {
             statusCode: 500,
             body: JSON.stringify({
-                message: 'some error happened',
+                message: err instanceof Error ? err.message : 'some error happened',
             }),
         };
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Very helpful type for handling exceptions. Now you can easily use `throw new Error("some error message")` to provide more descriptive messages for your consumers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
