### PR TITLE
feat: Update esbuild templates to match GA changes

### DIFF
--- a/nodejs14.x/cookiecutter-aws-sam-hello-powertools-typescript-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
+++ b/nodejs14.x/cookiecutter-aws-sam-hello-powertools-typescript-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
@@ -7,6 +7,7 @@
   "author": "SAM CLI",
   "license": "MIT",
   "dependencies": {
+    "esbuild": "^0.14.14"
   },
   "scripts": {
     "unit": "jest",
@@ -23,7 +24,6 @@
     "@types/node": "^17.0.13",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
-    "esbuild": "^0.14.14",
     "esbuild-jest": "^0.5.0",
     "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",

--- a/nodejs14.x/cookiecutter-aws-sam-hello-powertools-typescript-nodejs/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs14.x/cookiecutter-aws-sam-hello-powertools-typescript-nodejs/{{cookiecutter.project_name}}/template.yaml
@@ -29,6 +29,7 @@ Resources:
       {%- if cookiecutter["Powertools X-Ray Tracing"] == "enabled" or cookiecutter["Powertools Metrics"] == "enabled" or cookiecutter["Powertools Logging"] == "enabled" %}
       Environment:
         Variables:
+          NODE_OPTIONS: --enable-source-maps
           {%- if cookiecutter["Powertools X-Ray Tracing"] == "enabled" or cookiecutter["Powertools Metrics"] == "enabled"%}
           POWERTOOLS_SERVICE_NAME: helloWorld
           {%- endif %}

--- a/nodejs14.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
+++ b/nodejs14.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
@@ -7,6 +7,7 @@
   "author": "SAM CLI",
   "license": "MIT",
   "dependencies": {
+    "esbuild": "^0.14.14"
   },
   "scripts": {
     "unit": "jest",
@@ -20,7 +21,6 @@
     "@types/node": "^17.0.13",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
-    "esbuild": "^0.14.14",
     "esbuild-jest": "^0.5.0",
     "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",

--- a/nodejs14.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs14.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/template.yaml
@@ -23,6 +23,9 @@ Resources:
         - {{arch}}
       {%- endfor %}
       {%- endif %}
+      Environment:
+        Variables:
+          NODE_OPTIONS: --enable-source-maps
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/nodejs16.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
+++ b/nodejs16.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
@@ -7,6 +7,7 @@
   "author": "SAM CLI",
   "license": "MIT",
   "dependencies": {
+    "esbuild": "^0.14.14"
   },
   "scripts": {
     "unit": "jest",
@@ -20,7 +21,6 @@
     "@types/node": "^17.0.13",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
-    "esbuild": "^0.14.14",
     "esbuild-jest": "^0.5.0",
     "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",

--- a/nodejs16.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs16.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/template.yaml
@@ -23,6 +23,9 @@ Resources:
         - {{arch}}
       {%- endfor %}
       {%- endif %}
+      Environment:
+        Variables:
+          NODE_OPTIONS: --enable-source-maps
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api


### PR DESCRIPTION
*Description of changes:*
- Set source map environment variable so that it's configured correctly out-of-the-box.
- Move esbuild to be a non-dev dependency since esbuild will be using the npm install production flag and dev dependencies will no longer be installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
