### PR TITLE
swap axios for phin due smaller size

### DIFF
--- a/nodejs16.x/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/app.js
+++ b/nodejs16.x/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/app.js
@@ -1,4 +1,4 @@
-// const axios = require('axios')
+// const p = require('phin')
 // const url = 'http://checkip.amazonaws.com/';
 let response;
 
@@ -16,12 +16,12 @@ let response;
  */
 exports.lambdaHandler = async (event, context) => {
     try {
-        // const ret = await axios(url);
+        // const res = await p(url);
         response = {
             'statusCode': 200,
             'body': JSON.stringify({
                 message: 'hello world',
-                // location: ret.data.trim()
+                // location: res.body.toString()
             })
         }
     } catch (err) {

--- a/nodejs16.x/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
+++ b/nodejs16.x/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
@@ -7,7 +7,7 @@
   "author": "SAM CLI",
   "license": "MIT",
   "dependencies": {
-    "axios": ">=0.21.1"
+    "phin": ">=3.6.1"
   },
   "scripts": {
     "test": "mocha tests/unit/"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
In a previous project I was checking the size of my bundle using webpack bundleanalyzer plugin, I was quite surprised by the size of Axios because it was quite large for what I was doing in my Lambda function.
I started an investigation and I found that axios is not the largest HTTP client available for Node but not even the smaller. We know that the smaller is the bundle size the faster the cold start would be so reviewing different libraries I found phin that has a very lightweight implementation compared to axios and it performs similar duties.

Let me share a bit of data...

This is the axios node_modules vs phin node_modules inside ```.aws_sam``` folder after running ```sam build```
<img width="471" alt="Screenshot 2022-08-21 at 15 27 38" src="https://user-images.githubusercontent.com/210272/185798061-7660e689-aa87-449d-a0b8-31df8a4c4600.png">
Reviewing axios code, it doesn't use too many external libraries, just a couple but those are using several others that increase at the end the size of node_modules folder

Checking the size you can see on the left axios node_modules forlder size vs phin
<img width="529" alt="Screenshot 2022-08-21 at 15 28 01" src="https://user-images.githubusercontent.com/210272/185798134-4e2fbfbd-66c7-4c98-a6ce-976e6055ae58.png">

Then I reviewed also [bundlephobia](https://bundlephobia.com/) and also there you can see the huge difference between the two libraries
<img width="868" alt="Screenshot 2022-08-21 at 15 28 52" src="https://user-images.githubusercontent.com/210272/185798176-bcec28d9-8a64-4150-8cf8-ab4be2ef3375.png">
<img width="857" alt="Screenshot 2022-08-21 at 15 29 04" src="https://user-images.githubusercontent.com/210272/185798179-b848e42f-f1d0-4d68-8304-e02caca2aa0c.png">

Finally I checked the license and they are both using MIT license so if we agree to go ahead we should be able to swap axios in favour of phin.

I made the change only on Node.16x folder and if you agree I'm more than happy to apply to all the other occurrences 
<img width="451" alt="Screenshot 2022-08-21 at 16 19 33" src="https://user-images.githubusercontent.com/210272/185798242-b9ea3c83-103b-4c0d-a9c3-132ada6726e9.png">

Let me know what you think :) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
