### PR TITLE
Disable sourcemaps by default

### DIFF
--- a/nodejs14.x/cookiecutter-aws-sam-hello-powertools-typescript-nodejs/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs14.x/cookiecutter-aws-sam-hello-powertools-typescript-nodejs/{{cookiecutter.project_name}}/template.yaml
@@ -29,7 +29,6 @@ Resources:
       {%- if cookiecutter["Powertools X-Ray Tracing"] == "enabled" or cookiecutter["Powertools Metrics"] == "enabled" or cookiecutter["Powertools Logging"] == "enabled" %}
       Environment:
         Variables:
-          NODE_OPTIONS: --enable-source-maps
           {%- if cookiecutter["Powertools X-Ray Tracing"] == "enabled" or cookiecutter["Powertools Metrics"] == "enabled"%}
           POWERTOOLS_SERVICE_NAME: helloWorld
           {%- endif %}
@@ -51,7 +50,7 @@ Resources:
       BuildProperties:
         Minify: true
         Target: "es2020"
-        Sourcemap: true,
+        # Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
         EntryPoints: 
         - app.ts
 

--- a/nodejs14.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs14.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/template.yaml
@@ -23,9 +23,6 @@ Resources:
         - {{arch}}
       {%- endfor %}
       {%- endif %}
-      Environment:
-        Variables:
-          NODE_OPTIONS: --enable-source-maps
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
@@ -37,7 +34,7 @@ Resources:
       BuildProperties:
         Minify: true
         Target: "es2020"
-        Sourcemap: true
+        # Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
         EntryPoints: 
         - app.ts
 

--- a/nodejs16.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs16.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/template.yaml
@@ -23,9 +23,6 @@ Resources:
         - {{arch}}
       {%- endfor %}
       {%- endif %}
-      Environment:
-        Variables:
-          NODE_OPTIONS: --enable-source-maps
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
@@ -37,7 +34,7 @@ Resources:
       BuildProperties:
         Minify: true
         Target: "es2020"
-        Sourcemap: true
+        # Sourcemap: true # Enabling source maps will create the required NODE_OPTIONS environment variables on your lambda function during sam build
         EntryPoints: 
         - app.ts
 


### PR DESCRIPTION
*Description of changes:*
Since source maps generate an environment variable which requires the deployment role to have KMS:Encrypt as a policy, let's disable this in the template by default and make it opt-in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
