### PR TITLE
Feature/pytest standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ __pycache__
 .idea/
 .python-version
 venv/
+.venv/
 .env/

--- a/python3.7/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/unit/test_handler.py
+++ b/python3.7/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/unit/test_handler.py
@@ -62,7 +62,7 @@ def apigw_event():
     }
 
 
-def test_lambda_handler(apigw_event, mocker):
+def test_lambda_handler(apigw_event):
 
     ret = app.lambda_handler(apigw_event, "")
     data = json.loads(ret["body"])
@@ -70,4 +70,3 @@ def test_lambda_handler(apigw_event, mocker):
     assert ret["statusCode"] == 200
     assert "message" in ret["body"]
     assert data["message"] == "hello world"
-    # assert "location" in data.dict_keys()

--- a/python3.8/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/requirements.txt
+++ b/python3.8/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest
-pytest-mock
 boto3
+requests

--- a/python3.8/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/unit/test_handler.py
+++ b/python3.8/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/unit/test_handler.py
@@ -62,7 +62,7 @@ def apigw_event():
     }
 
 
-def test_lambda_handler(apigw_event, mocker):
+def test_lambda_handler(apigw_event):
 
     ret = app.lambda_handler(apigw_event, "")
     data = json.loads(ret["body"])
@@ -70,4 +70,3 @@ def test_lambda_handler(apigw_event, mocker):
     assert ret["statusCode"] == 200
     assert "message" in ret["body"]
     assert data["message"] == "hello world"
-    # assert "location" in data.dict_keys()

--- a/python3.9/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/integration/test_api_gateway.py
+++ b/python3.9/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/integration/test_api_gateway.py
@@ -15,13 +15,17 @@ class TestApiGateway:
     def api_gateway_url(self):
         """ Get the API Gateway URL from Cloudformation Stack outputs """
         stack_name = os.environ.get("AWS_SAM_STACK_NAME")
+
+        if stack_name is None:
+            raise ValueError('Please set the AWS_SAM_STACK_NAME environment variable to the name of your stack')
+
         client = boto3.client("cloudformation")
 
         try:
             response = client.describe_stacks(StackName=stack_name)
         except Exception as e:
             raise Exception(
-                f"Cannot find stack {stack_name} \n" f'Please make sure stack with the name "{stack_name}" exists'
+                f"Cannot find stack {stack_name} \n" f'Please make sure a stack with the name "{stack_name}" exists'
             ) from e
 
         stacks = response["Stacks"]

--- a/python3.9/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/integration/test_api_gateway.py
+++ b/python3.9/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/integration/test_api_gateway.py
@@ -14,6 +14,7 @@ class TestApiGateway(TestCase):
 
     @classmethod
     def get_stack_name(cls) -> str:
+        # HELLO IAIN
         stack_name = os.environ.get("AWS_SAM_STACK_NAME")
         if not stack_name:
             raise Exception(

--- a/python3.9/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/integration/test_api_gateway.py
+++ b/python3.9/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/integration/test_api_gateway.py
@@ -12,7 +12,7 @@ Make sure env variable AWS_SAM_STACK_NAME exists with the name of the stack we a
 class TestApiGateway:
 
     @pytest.fixture()
-    def api_gateway_url(self, set_env):
+    def api_gateway_url(self):
         """ Get the API Gateway URL from Cloudformation Stack outputs """
         stack_name = os.environ.get("AWS_SAM_STACK_NAME")
         client = boto3.client("cloudformation")

--- a/python3.9/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/integration/test_api_gateway.py
+++ b/python3.9/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/integration/test_api_gateway.py
@@ -1,7 +1,7 @@
 import os
-from unittest import TestCase
 
 import boto3
+import pytest
 import requests
 
 """
@@ -9,48 +9,33 @@ Make sure env variable AWS_SAM_STACK_NAME exists with the name of the stack we a
 """
 
 
-class TestApiGateway(TestCase):
-    api_endpoint: str
+class TestApiGateway:
 
-    @classmethod
-    def get_stack_name(cls) -> str:
-        # HELLO IAIN
+    @pytest.fixture()
+    def api_gateway_url(self, set_env):
+        """ Get the API Gateway URL from Cloudformation Stack outputs """
         stack_name = os.environ.get("AWS_SAM_STACK_NAME")
-        if not stack_name:
-            raise Exception(
-                "Cannot find env var AWS_SAM_STACK_NAME. \n"
-                "Please setup this environment variable with the stack name where we are running integration tests."
-            )
-
-        return stack_name
-
-    def setUp(self) -> None:
-        """
-        Based on the provided env variable AWS_SAM_STACK_NAME,
-        here we use cloudformation API to find out what the HelloWorldApi URL is
-        """
-        stack_name = TestApiGateway.get_stack_name()
-
         client = boto3.client("cloudformation")
 
         try:
             response = client.describe_stacks(StackName=stack_name)
         except Exception as e:
             raise Exception(
-                f"Cannot find stack {stack_name}. \n" f'Please make sure stack with the name "{stack_name}" exists.'
+                f"Cannot find stack {stack_name} \n" f'Please make sure stack with the name "{stack_name}" exists'
             ) from e
 
         stacks = response["Stacks"]
-
         stack_outputs = stacks[0]["Outputs"]
         api_outputs = [output for output in stack_outputs if output["OutputKey"] == "HelloWorldApi"]
-        self.assertTrue(api_outputs, f"Cannot find output HelloWorldApi in stack {stack_name}")
 
-        self.api_endpoint = api_outputs[0]["OutputValue"]
+        if not api_outputs:
+            raise KeyError(f"HelloWorldAPI not found in stack {stack_name}")
 
-    def test_api_gateway(self):
-        """
-        Call the API Gateway endpoint and check the response
-        """
-        response = requests.get(self.api_endpoint)
-        self.assertDictEqual(response.json(), {"message": "hello world"})
+        return api_outputs[0]["OutputValue"]  # Extract url from stack outputs
+
+    def test_api_gateway(self, api_gateway_url):
+        """ Call the API Gateway endpoint and check the response """
+        response = requests.get(api_gateway_url)
+
+        assert response.status_code == 200
+        assert response.json() == {"message": "hello world"}

--- a/python3.9/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/requirements.txt
+++ b/python3.9/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest
-pytest-mock
 boto3
+requests

--- a/python3.9/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/unit/test_handler.py
+++ b/python3.9/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/unit/test_handler.py
@@ -62,7 +62,7 @@ def apigw_event():
     }
 
 
-def test_lambda_handler(apigw_event, mocker):
+def test_lambda_handler(apigw_event):
 
     ret = app.lambda_handler(apigw_event, "")
     data = json.loads(ret["body"])
@@ -70,4 +70,3 @@ def test_lambda_handler(apigw_event, mocker):
     assert ret["statusCode"] == 200
     assert "message" in ret["body"]
     assert data["message"] == "hello world"
-    # assert "location" in data.dict_keys()


### PR DESCRIPTION
*Issue #276 

*Description of changes:*

As agreed with @jfuss in Issue #276 this PR standardizes the test framework to be pytest across the unit and integration tests in the aws-sam-hello-python cookiecutter templates.  Specifically:

* Remove unittest framework
* Create new api_gateway_url test fixture that gets the new api-url from cloudformation stack
* Improved error handling
* Remove unused imports and add missing requests requirement

I can confirm I've tested the new template on 3.7, 3.8 and 3.9 and it all works well

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
