### PR TITLE
Fixed #267 - Upgrade rust template dependencies and fixed makefile

### DIFF
--- a/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/Cargo.toml
+++ b/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test-1"
+name = "{{ cookiecutter.project_slug }}"
 version = "0.1.0"
 edition = "2021"
 

--- a/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/Cargo.toml
+++ b/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "{{ cookiecutter.project_slug }}"
+name = "test-1"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.8"
-aws-sdk-dynamodb = "0.8"
-aws-smithy-client = { version = "0.38", features = ["test-util"] }
-lambda_http = "0.5"
-tokio = { version = "1", features = ["full"] }
+aws-config = "0.49.0"
+aws-sdk-dynamodb = "0.19.0"
+aws-smithy-client = { version = "0.49.0", features = ["test-util"] }
+lambda_http = "0.6.1"
+tokio = { version = "1.21.1", features = ["full"] }
 
 [dev-dependencies]
-aws-smithy-http = "0.38"
-aws-types = { version = "0.8", features = ["hardcoded-credentials"] }
-http = "0.2"
+aws-smithy-http = "0.49.0"
+aws-types = { version = "0.49.0", features = ["hardcoded-credentials"] }
+http = "0.2.8"

--- a/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/Makefile
+++ b/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/Makefile
@@ -1,7 +1,7 @@
 {% if cookiecutter.architecture == 'arm64' -%}
-CARGO_LAMBDA_FLAGS = '--arm64'
+CARGO_LAMBDA_FLAGS = --arm64
 {%- else -%}
-CARGO_LAMBDA_FLAGS = ''
+CARGO_LAMBDA_FLAGS = --target x86_64-unknown-linux-gnu
 {%- endif %}
 
 .PHONY: build

--- a/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/README.md
+++ b/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/README.md
@@ -23,6 +23,10 @@ The AWS Toolkit is an open source plug-in for popular IDEs that uses the SAM CLI
 * [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
 * [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
 
+
+## Requirments
+* This template was tested with Rust v1.61.0 and above.
+
 ## Deploy the sample application
 
 To deploy the application, you need the folllowing tools:

--- a/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/src/main.rs
+++ b/provided.al2/rust/cookiecutter-aws-sam-hello-rust/{{ cookiecutter.project_slug }}/src/main.rs
@@ -1,5 +1,5 @@
 use aws_sdk_dynamodb::{model::AttributeValue, Client};
-use lambda_http::{service_fn, Body, Error, IntoResponse, Request, RequestExt, Response};
+use lambda_http::{service_fn, Body, Error, Request, RequestExt, Response};
 use std::env;
 
 /// Main function
@@ -29,12 +29,12 @@ async fn put_item(
     client: &Client,
     table_name: &str,
     request: Request,
-) -> Result<impl IntoResponse, Error> {
+) -> Result<Response<Body>, Error> {
     // Extract path parameter from request
     let path_parameters = request.path_parameters();
     let id = match path_parameters.first("id") {
         Some(id) => id,
-        None => return Ok(Response::builder().status(400).body("id is required")?),
+        None => return Ok(Response::builder().status(400).body("id is required".into())?),
     };
 
     // Extract body from request
@@ -55,8 +55,8 @@ async fn put_item(
 
     // Return a response to the end-user
     match res {
-        Ok(_) => Ok(Response::builder().status(200).body("item saved")?),
-        Err(_) => Ok(Response::builder().status(500).body("internal error")?),
+        Ok(_) => Ok(Response::builder().status(200).body("item saved".into())?),
+        Err(_) => Ok(Response::builder().status(500).body("internal error".into())?),
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:* #267 

*Description of changes:*

This fixed bug #267. It also updates the dependencies to the latest version. It also fixes some trait mismatch bug in `src/main.rs` because of the lambda-http upgrade.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
