### PR TITLE
Update hello world ts to use correct error logging

### DIFF
--- a/nodejs16.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/hello-world/app.ts
+++ b/nodejs16.x/cookiecutter-aws-sam-hello-typescript-nodejs/{{cookiecutter.project_name}}/hello-world/app.ts
@@ -20,7 +20,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
             }),
         };
     } catch (err: unknown) {
-        console.log(err);
+        console.error(err);
         response = {
             statusCode: 500,
             body: JSON.stringify({


### PR DESCRIPTION
Issue #, if available: N/A
Rationale behind the change:
- Developers will likely copy and modify the hello world template when using creating a new project. The error would be logged at an incorrect level if an error is thrown in a real world project without anyone changing the template catch block code.

Description of changes:
- Change the hello world typescript handler to use console.error instead of console.log when an error is thrown.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
