### PR TITLE
remove unused Makefiles from the go templates

### DIFF
--- a/go1.x/cookiecutter-aws-sam-eventbridge-hello-golang/{{cookiecutter.project_name}}/Makefile
+++ b/go1.x/cookiecutter-aws-sam-eventbridge-hello-golang/{{cookiecutter.project_name}}/Makefile
@@ -1,5 +1,0 @@
-.PHONY: build
-
-build:
-	go mod download github.com/aws/aws-lambda-go
-	sam build

--- a/go1.x/cookiecutter-aws-sam-eventbridge-schema-app-golang/{{cookiecutter.project_name}}/Makefile
+++ b/go1.x/cookiecutter-aws-sam-eventbridge-schema-app-golang/{{cookiecutter.project_name}}/Makefile
@@ -1,5 +1,0 @@
-.PHONY: build
-
-build:
-	go mod download github.com/aws/aws-lambda-go
-	sam build

--- a/go1.x/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/Makefile
+++ b/go1.x/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/Makefile
@@ -1,4 +1,0 @@
-.PHONY: build
-
-build:
-	sam build

--- a/go1.x/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/README.md
+++ b/go1.x/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/README.md
@@ -26,12 +26,6 @@ This is a sample template for {{ cookiecutter.project_name }} - Below is a brief
 In this example we use the built-in `sam build` to automatically download all the dependencies and package our build target.   
 Read more about [SAM Build here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-build.html) 
 
-The `sam build` command is wrapped inside of the `Makefile`. To execute this simply run
- 
-```shell
-make
-```
-
 ### Local development
 
 **Invoking function locally through local API Gateway**

--- a/go1.x/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/Makefile
+++ b/go1.x/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/Makefile
@@ -1,4 +1,0 @@
-.PHONY: build
-
-build:
-	sam build

--- a/provided.al2/go/cookiecutter-aws-sam-eventbridge-hello-golang/{{cookiecutter.project_name}}/Makefile
+++ b/provided.al2/go/cookiecutter-aws-sam-eventbridge-hello-golang/{{cookiecutter.project_name}}/Makefile
@@ -1,5 +1,0 @@
-.PHONY: build
-
-build:
-	go mod download github.com/aws/aws-lambda-go
-	sam build

--- a/provided.al2/go/cookiecutter-aws-sam-eventbridge-schema-app-golang/{{cookiecutter.project_name}}/Makefile
+++ b/provided.al2/go/cookiecutter-aws-sam-eventbridge-schema-app-golang/{{cookiecutter.project_name}}/Makefile
@@ -1,5 +1,0 @@
-.PHONY: build
-
-build:
-	go mod download github.com/aws/aws-lambda-go
-	sam build

--- a/provided.al2/go/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/Makefile
+++ b/provided.al2/go/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/Makefile
@@ -1,4 +1,0 @@
-.PHONY: build
-
-build:
-	sam build

--- a/provided.al2/go/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/README.md
+++ b/provided.al2/go/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/README.md
@@ -28,10 +28,6 @@ Read more about [SAM Build here](https://docs.aws.amazon.com/serverless-applicat
 
 The `sam build` command is wrapped inside of the `Makefile`. To execute this simply run
  
-```shell
-make
-```
-
 ### Local development
 
 **Invoking function locally through local API Gateway**

--- a/provided.al2/go/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/Makefile
+++ b/provided.al2/go/cookiecutter-aws-sam-hello-step-functions-sample-app/{{cookiecutter.project_name}}/Makefile
@@ -1,4 +1,0 @@
-.PHONY: build
-
-build:
-	sam build


### PR DESCRIPTION
*Description of changes:*

These appear unused. I suggest removing them to eliminate possible confusion with the unrelated `Makefile` `BuildMethod`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
