### PR TITLE
fix: non-custom GH action for `manifest.json`

### DIFF
--- a/.github/workflows/manifest-backward-compability-check.yml
+++ b/.github/workflows/manifest-backward-compability-check.yml
@@ -9,8 +9,15 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: xalvarez/prevent-file-change-action@v1
+      - name: Checkout commit
+        uses: actions/checkout@v3
         with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          pattern: manifest.json
+          fetch-depth: 3
+      - name: Check for manifest.json changes
+        shell: bash
+        run: |
+          if git log --name-only -n 2 ${{github.sha}} | grep "manifest.json"; then
+            echo "Backward Incompatible change found!"
+            exit 1
+          fi
 


### PR DESCRIPTION
- always check for backward incompatibility.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
