### PR TITLE
fix: move esbuild to dependencies

### DIFF
--- a/nodejs18.x/hello-ts/{{cookiecutter.project_name}}/hello-world/package.json
+++ b/nodejs18.x/hello-ts/{{cookiecutter.project_name}}/hello-world/package.json
@@ -12,13 +12,15 @@
     "compile": "tsc",
     "test": "npm run compile && npm run unit"
   },
+  "dependencies": {
+    "esbuild": "^0.14.14"
+  },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.92",
     "@types/jest": "^29.2.0",
     "@types/node": "^18.11.4",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
-    "esbuild": "^0.14.14",
     "esbuild-jest": "^0.5.0",
     "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/4183
https://github.com/aws/aws-sam-cli/issues/4183#issuecomment-1436240250

*Description of changes:*

Move `esbuild` package to `dependecies` from `devDependencies`
The above issue is closed, but some people including me still have trouble after closed.
The other templates ([nodejs16.x ts](https://github.com/aws/aws-sam-cli-app-templates/blob/616cd1898c00c13edd654f2fb8c4931033c881da/nodejs16.x/hello-ts/%7B%7Bcookiecutter.project_name%7D%7D/hello-world/package.json), [nodejs16.x ts-pt](https://github.com/aws/aws-sam-cli-app-templates/blob/616cd1898c00c13edd654f2fb8c4931033c881da/nodejs16.x/hello-ts-pt/%7B%7Bcookiecutter.project_name%7D%7D/hello-world/package.json), [nodejs18.x ts-pt](https://github.com/aws/aws-sam-cli-app-templates/blob/616cd1898c00c13edd654f2fb8c4931033c881da/nodejs18.x/hello-ts-pt/%7B%7Bcookiecutter.project_name%7D%7D/hello-world/package.json)) have `esbuild` as `dependencies` not `devDependencies`, so I think this template should follow to keep consistency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
