### PR TITLE
fix: add py3.10 tests back

### DIFF
--- a/.github/workflows/build_test_invoke.yml
+++ b/.github/workflows/build_test_invoke.yml
@@ -66,9 +66,9 @@ jobs:
           - version: '3.10'
             type: 'Test'
             file: 'tests/integration/unit_test/test_unit_test_python3_10.py'
-          # - version: '3.10'
-          #   type: 'Invoke'
-          #   file: 'tests/integration/build_invoke/python/test_python_3_10.py'
+          - version: '3.10'
+            type: 'Invoke'
+            file: 'tests/integration/build_invoke/python/test_python_3_10.py'
     env:
       PYTHON_VERSION_INSTALL: ${{ matrix.version }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Once build image is published, we can merge this PR to enable build & invoke tests for python3.10

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
