### PR TITLE
Mock S3 response for unit test

### DIFF
--- a/dotnetcore3.1/s3/{{cookiecutter.project_name}}/test/{{cookiecutter.project_name}}.Tests/FunctionTest.cs
+++ b/dotnetcore3.1/s3/{{cookiecutter.project_name}}/test/{{cookiecutter.project_name}}.Tests/FunctionTest.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
+using Moq;
 using Amazon.Lambda;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.TestUtilities;
@@ -23,51 +25,52 @@ namespace {{cookiecutter.project_name}}.Tests
         [Fact]
         public async Task TestS3EventLambdaFunction()
         {
-            IAmazonS3 s3Client = new AmazonS3Client(RegionEndpoint.USWest2);
             var context = new TestLambdaContext();
 
             var bucketName = "lambda-S3JsonLogger-".ToLower() + DateTime.Now.Ticks;
             var key = "text.txt";
 
-            // Create a bucket an object to setup a test data.
-            await s3Client.PutBucketAsync(bucketName);
-            try
-            {
-                await s3Client.PutObjectAsync(new PutObjectRequest
-                {
-                    BucketName = bucketName,
-                    Key = key,
-                    ContentBody = "sample data"
-                });
+            // BEGIN mocking s3Client
+            var s3ClientMock = new Mock<IAmazonS3>();
+            s3ClientMock.Setup(x => x.Config)
+                        .Returns(new AmazonS3Config { RegionEndpoint = RegionEndpoint.USWest2 });
 
-                // Setup the S3 event object that S3 notifications would create with the fields used by the Lambda function.
-                var s3Event = new S3Event
+            var response = new GetObjectMetadataResponse();
+            response.Headers.ContentType = "text/plain";
+            response.Expires = DateTime.Now;
+
+            s3ClientMock.Setup(x => x.GetObjectMetadataAsync(
+                It.Is<string>(_bucketName => _bucketName == bucketName),    // Mock with the given bucket name
+                It.Is<string>(_key => _key == key),                         // Mock with the given key
+                It.IsAny<CancellationToken>())
+            )
+                .Returns(Task.FromResult(response));
+        
+            var s3Client = s3ClientMock.Object;
+            // END mocking s3Client
+
+
+            // Setup the S3 event object that S3 notifications would create with the fields used by the Lambda function.
+            var s3Event = new S3Event
+            {
+                Records = new List<S3EventNotification.S3EventNotificationRecord>
                 {
-                    Records = new List<S3EventNotification.S3EventNotificationRecord>
+                    new S3EventNotification.S3EventNotificationRecord
                     {
-                        new S3EventNotification.S3EventNotificationRecord
+                        S3 = new S3EventNotification.S3Entity
                         {
-                            S3 = new S3EventNotification.S3Entity
-                            {
-                                Bucket = new S3EventNotification.S3BucketEntity {Name = bucketName },
-                                Object = new S3EventNotification.S3ObjectEntity {Key = key }
-                            }
+                            Bucket = new S3EventNotification.S3BucketEntity { Name = bucketName },
+                            Object = new S3EventNotification.S3ObjectEntity { Key = key }
                         }
                     }
-                };
+                }
+            };
 
-                // Invoke the lambda function and confirm the content type was returned.
-                var function = new Function(s3Client);
-                var contentType = await function.FunctionHandler(s3Event, context);
+            // Invoke the lambda function and confirm the content type was returned.
+            var function = new Function(s3Client);
+            var contentType = await function.FunctionHandler(s3Event, context);
 
-                Assert.Equal("text/plain", contentType);
-
-            }
-            finally
-            {
-                // Clean up the test data
-                await AmazonS3Util.DeleteS3BucketWithObjectsAsync(s3Client, bucketName);
-            }
+            Assert.Equal("text/plain", contentType);
         }
     }
 }

--- a/dotnetcore3.1/s3/{{cookiecutter.project_name}}/test/{{cookiecutter.project_name}}.Tests/{{cookiecutter.project_name}}.Tests.csproj
+++ b/dotnetcore3.1/s3/{{cookiecutter.project_name}}/test/{{cookiecutter.project_name}}.Tests/{{cookiecutter.project_name}}.Tests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.0.18" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/tests/integration/unit_test/test_unit_test_dotnetcore3_1.py
+++ b/tests/integration/unit_test/test_unit_test_dotnetcore3_1.py
@@ -12,10 +12,9 @@ class UnitTest_dotnetcore3_1_cookiecutter_aws_sam_hello_step_functions_sample_ap
     code_directories = ["tests/StockBuyer.Test", "tests/StockChecker.Test", "tests/StockSeller.Test"]
 
 
-# TODO: Re-enable this test once issues are fixed
-# class UnitTest_dotnetcore3_1_cookiecutter_aws_sam_quick_start_s3_dotnet(UnitTestBase.DotNetCoreUnitTestBase):
-#     directory = "dotnetcore3.1/s3"
-#     code_directories = ["test/project.Tests"]
+class UnitTest_dotnetcore3_1_cookiecutter_aws_sam_quick_start_s3_dotnet(UnitTestBase.DotNetCoreUnitTestBase):
+    directory = "dotnetcore3.1/s3"
+    code_directories = ["test/project.Tests"]
     
 
 class UnitTest_dotnetcore3_1_cookiecutter_aws_sam_quick_start_sqs_dotnet(UnitTestBase.DotNetCoreUnitTestBase):


### PR DESCRIPTION
*Issue:*  #195 

*Description of changes:*

Mock S3 response for unit testing, avoid creating S3 bucket. The current way is supposed to be integration testing rather than init testing of a code block.
