### PR TITLE
Update Docker build image for Java11 `hello-img-gradle` template

### DIFF
--- a/java11/hello-img-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/Dockerfile
+++ b/java11/hello-img-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/java:11 as build-image
+FROM public.ecr.aws/sam/build-java11:latest as build-image
 
 ARG SCRATCH_DIR=/var/task/build
 


### PR DESCRIPTION
*Issue #:* N/A

*Description of changes:*

Since this is a simple change, I didn't raise an issue for this.
This will basically change the build image for Java11 `hello-img-gradle` template. It will follow best practice to use the correct image for the right purpose as well as make the template consistent with others.

Tested with
`pytest -vvv tests/integration/unit_test/test_unit_test_java11.py`
`pytest -vvv tests/integration/build_invoke/dotnet/test_build_invoke_java11.py`
