### PR TITLE
fix: use correct app template name for the rust dynamo db template

### DIFF
--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -1154,7 +1154,7 @@
       "directory": "al2/rust/hello-ddb",
       "displayName": "DynamoDB Example",
       "dependencyManager": "cargo",
-      "appTemplate": "hello-world",
+      "appTemplate": "hello-world-ddb",
       "packageType": "Zip",
       "useCaseName": "DynamoDB Example"
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli-app-templates/issues/367

*Description of changes:*
Use a correct app template name for the rust dynamo db template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
