### PR TITLE
Unused Body struct removed from the hello world Rust example

### DIFF
--- a/al2/rust/hello/{{ cookiecutter.project_slug }}/rust_app/src/main.rs
+++ b/al2/rust/hello/{{ cookiecutter.project_slug }}/rust_app/src/main.rs
@@ -19,11 +19,6 @@ struct Response {
     body: String,
 }
 
-#[derive(Serialize)]
-struct Body {
-    message: String,
-}
-
 /// This is the main body for the function.
 /// Write your code inside it.
 /// There are some code example in the following URLs:


### PR DESCRIPTION
*Issue #, if available:*

No issue, just a small fix to remove unused code.

*Description of changes:*

I removed the Body struct from the hello world Rust example because it is not used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
