### PR TITLE
ci: add feat* rule to run github actions

### DIFF
--- a/.github/workflows/build_test_invoke.yml
+++ b/.github/workflows/build_test_invoke.yml
@@ -2,10 +2,10 @@ name: Build
 
 on:
   pull_request:
-    branches: ['master']
+    branches: [master, "feat*"]
   merge_group:
     types: [checks_requested]
-    branches: [master]
+    branches: [master, "feat*"]
 
 env:
   PYTHON_VERSION_INSTALL: '3.7'


### PR DESCRIPTION
Enable GHA CI jobs to run against `develop` and `feat*` branches.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
