### PR TITLE
update powertools to v1.0.1

### DIFF
--- a/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -12,16 +12,13 @@
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
     {%- if cookiecutter["Powertools Tracing"] == "enabled"%}
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.11.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.0.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.0.1" />
     {%- endif %}
     {%- if cookiecutter["Powertools Metrics"] == "enabled"%}
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.0.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.0.1" />
     {%- endif %}
     {%- if cookiecutter["Powertools Logging"] == "enabled"%}
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.0.0" />
-    {%- endif %}
-    {%- if cookiecutter["Powertools Tracing"] == "enabled" or cookiecutter["Powertools Logging"] == "enabled" or cookiecutter["Powertools Metrics"] == "enabled" %}
-    <PackageReference Include="AWS.Lambda.Powertools.Common" Version="1.0.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.0.1" />
     {%- endif %}
   </ItemGroup>
 </Project>

--- a/dotnet6/hello-pt/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet6/hello-pt/{{cookiecutter.project_name}}/template.yaml
@@ -12,6 +12,9 @@ Globals:
   Api:
     # More info about OpenApiVersion: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html#sam-api-openapiversion
     OpenApiVersion: 3.0.1
+    {%- if cookiecutter["Powertools Tracing"] == "enabled"%}
+    TracingEnabled: true
+    {%- endif %}
 
 Resources:
   HelloWorldFunction:

--- a/dotnet6/hello-pt/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet6/hello-pt/{{cookiecutter.project_name}}/template.yaml
@@ -12,9 +12,6 @@ Globals:
   Api:
     # More info about OpenApiVersion: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-api.html#sam-api-openapiversion
     OpenApiVersion: 3.0.1
-    {%- if cookiecutter["Powertools Tracing"] == "enabled"%}
-    TracingEnabled: true
-    {%- endif %}
 
 Resources:
   HelloWorldFunction:


### PR DESCRIPTION
Update Powertools template to v 1.0.1
Removed Common package because it is not needed
Removed TracingEnabled: true from Globals in the template. This property was failing on Sam cli. Still present in the function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
