### PR TITLE
Replace cloudformation cli with sam cli in Readme files - Nodejs templates

### DIFF
--- a/nodejs12.x/cw-event/{{cookiecutter.project_name}}/README.md
+++ b/nodejs12.x/cw-event/{{cookiecutter.project_name}}/README.md
@@ -134,7 +134,7 @@ my-application$ AWS_SAM_STACK_NAME=<stack-name> npm run integ-test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs12.x/hello-img/{{cookiecutter.project_name}}/README.md
+++ b/nodejs12.x/hello-img/{{cookiecutter.project_name}}/README.md
@@ -106,7 +106,7 @@ hello-world$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs12.x/hello/{{cookiecutter.project_name}}/README.md
+++ b/nodejs12.x/hello/{{cookiecutter.project_name}}/README.md
@@ -121,7 +121,7 @@ hello-world$ AWS_SAM_STACK_NAME=<stack-name> npm run integ-test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs12.x/s3/{{cookiecutter.project_name}}/README.md
+++ b/nodejs12.x/s3/{{cookiecutter.project_name}}/README.md
@@ -145,7 +145,7 @@ my-application$ AWS_SAM_STACK_NAME=<stack-name> npm run integ-test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs12.x/scratch/{{cookiecutter.project_name}}/README.md
+++ b/nodejs12.x/scratch/{{cookiecutter.project_name}}/README.md
@@ -134,7 +134,7 @@ my-application$ AWS_SAM_STACK_NAME=<stack-name> npm run integ-test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs12.x/sns/{{cookiecutter.project_name}}/README.md
+++ b/nodejs12.x/sns/{{cookiecutter.project_name}}/README.md
@@ -140,7 +140,7 @@ my-application$ AWS_SAM_STACK_NAME=<stack-name> npm run integ-test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs12.x/sqs/{{cookiecutter.project_name}}/README.md
+++ b/nodejs12.x/sqs/{{cookiecutter.project_name}}/README.md
@@ -134,7 +134,7 @@ my-application$ AWS_SAM_STACK_NAME=<stack-name> npm run integ-test
 To delete the sample application and the bucket that you created, use the AWS CLI.
 
 ```bash
-my-application$ aws cloudformation delete-stack --stack-name sam-app
+my-application$ sam delete --stack-name sam-app
 my-application$ aws s3 rb s3://BUCKET_NAME
 ```
 

--- a/nodejs12.x/step-func-conn/{{cookiecutter.project_name}}/README.md
+++ b/nodejs12.x/step-func-conn/{{cookiecutter.project_name}}/README.md
@@ -127,7 +127,7 @@ Check [`makefile`](./makefile) for details
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs12.x/step-func/{{cookiecutter.project_name}}/README.md
+++ b/nodejs12.x/step-func/{{cookiecutter.project_name}}/README.md
@@ -106,7 +106,7 @@ integration-tests$ AWS_SAM_STACK_NAME=<stack-name> npm run integ-test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs12.x/web-conn/{{cookiecutter.project_name}}/README.md
+++ b/nodejs12.x/web-conn/{{cookiecutter.project_name}}/README.md
@@ -150,7 +150,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs12.x/web/{{cookiecutter.project_name}}/README.md
+++ b/nodejs12.x/web/{{cookiecutter.project_name}}/README.md
@@ -154,7 +154,7 @@ my-application$ AWS_SAM_STACK_NAME=<stack-name> npm run integ-test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs14.x/cw-event/{{cookiecutter.project_name}}/README.md
+++ b/nodejs14.x/cw-event/{{cookiecutter.project_name}}/README.md
@@ -130,7 +130,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs14.x/hello-img/{{cookiecutter.project_name}}/README.md
+++ b/nodejs14.x/hello-img/{{cookiecutter.project_name}}/README.md
@@ -106,7 +106,7 @@ hello-world$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs14.x/hello-ts/{{cookiecutter.project_name}}/README.md
+++ b/nodejs14.x/hello-ts/{{cookiecutter.project_name}}/README.md
@@ -117,7 +117,7 @@ hello-world$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs14.x/hello/{{cookiecutter.project_name}}/README.md
+++ b/nodejs14.x/hello/{{cookiecutter.project_name}}/README.md
@@ -117,7 +117,7 @@ hello-world$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs14.x/s3/{{cookiecutter.project_name}}/README.md
+++ b/nodejs14.x/s3/{{cookiecutter.project_name}}/README.md
@@ -141,7 +141,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs14.x/scratch/{{cookiecutter.project_name}}/README.md
+++ b/nodejs14.x/scratch/{{cookiecutter.project_name}}/README.md
@@ -130,7 +130,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs14.x/sns/{{cookiecutter.project_name}}/README.md
+++ b/nodejs14.x/sns/{{cookiecutter.project_name}}/README.md
@@ -136,7 +136,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs14.x/sqs/{{cookiecutter.project_name}}/README.md
+++ b/nodejs14.x/sqs/{{cookiecutter.project_name}}/README.md
@@ -130,7 +130,7 @@ my-application$ npm run test
 To delete the sample application and the bucket that you created, use the AWS CLI.
 
 ```bash
-my-application$ aws cloudformation delete-stack --stack-name sam-app
+my-application$ sam delete --stack-name sam-app
 my-application$ aws s3 rb s3://BUCKET_NAME
 ```
 

--- a/nodejs14.x/step-func-conn/{{cookiecutter.project_name}}/README.md
+++ b/nodejs14.x/step-func-conn/{{cookiecutter.project_name}}/README.md
@@ -127,7 +127,7 @@ Check [`makefile`](./makefile) for details
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs14.x/step-func/{{cookiecutter.project_name}}/README.md
+++ b/nodejs14.x/step-func/{{cookiecutter.project_name}}/README.md
@@ -126,7 +126,7 @@ Check [`makefile`](./makefile) for details
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs14.x/web-conn/{{cookiecutter.project_name}}/README.md
+++ b/nodejs14.x/web-conn/{{cookiecutter.project_name}}/README.md
@@ -150,7 +150,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs14.x/web/{{cookiecutter.project_name}}/README.md
+++ b/nodejs14.x/web/{{cookiecutter.project_name}}/README.md
@@ -150,7 +150,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs16.x/cw-event/{{cookiecutter.project_name}}/README.md
+++ b/nodejs16.x/cw-event/{{cookiecutter.project_name}}/README.md
@@ -130,7 +130,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs16.x/hello-img/{{cookiecutter.project_name}}/README.md
+++ b/nodejs16.x/hello-img/{{cookiecutter.project_name}}/README.md
@@ -106,7 +106,7 @@ hello-world$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs16.x/hello-ts/{{cookiecutter.project_name}}/README.md
+++ b/nodejs16.x/hello-ts/{{cookiecutter.project_name}}/README.md
@@ -117,7 +117,7 @@ hello-world$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs16.x/hello/{{cookiecutter.project_name}}/README.md
+++ b/nodejs16.x/hello/{{cookiecutter.project_name}}/README.md
@@ -117,7 +117,7 @@ hello-world$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs16.x/s3/{{cookiecutter.project_name}}/README.md
+++ b/nodejs16.x/s3/{{cookiecutter.project_name}}/README.md
@@ -141,7 +141,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs16.x/scratch/{{cookiecutter.project_name}}/README.md
+++ b/nodejs16.x/scratch/{{cookiecutter.project_name}}/README.md
@@ -130,7 +130,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs16.x/sns/{{cookiecutter.project_name}}/README.md
+++ b/nodejs16.x/sns/{{cookiecutter.project_name}}/README.md
@@ -136,7 +136,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs16.x/sqs/{{cookiecutter.project_name}}/README.md
+++ b/nodejs16.x/sqs/{{cookiecutter.project_name}}/README.md
@@ -130,7 +130,7 @@ my-application$ npm run test
 To delete the sample application and the bucket that you created, use the AWS CLI.
 
 ```bash
-my-application$ aws cloudformation delete-stack --stack-name sam-app
+my-application$ sam delete --stack-name sam-app
 my-application$ aws s3 rb s3://BUCKET_NAME
 ```
 

--- a/nodejs16.x/step-func-conn/{{cookiecutter.project_name}}/README.md
+++ b/nodejs16.x/step-func-conn/{{cookiecutter.project_name}}/README.md
@@ -127,7 +127,7 @@ Check [`makefile`](./makefile) for details
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs16.x/step-func/{{cookiecutter.project_name}}/README.md
+++ b/nodejs16.x/step-func/{{cookiecutter.project_name}}/README.md
@@ -127,7 +127,7 @@ Check [`makefile`](./makefile) for details
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs16.x/web-conn/{{cookiecutter.project_name}}/README.md
+++ b/nodejs16.x/web-conn/{{cookiecutter.project_name}}/README.md
@@ -150,7 +150,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs16.x/web/{{cookiecutter.project_name}}/README.md
+++ b/nodejs16.x/web/{{cookiecutter.project_name}}/README.md
@@ -150,7 +150,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs18.x/cw-event/{{cookiecutter.project_name}}/README.md
+++ b/nodejs18.x/cw-event/{{cookiecutter.project_name}}/README.md
@@ -130,7 +130,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs18.x/hello-img/{{cookiecutter.project_name}}/README.md
+++ b/nodejs18.x/hello-img/{{cookiecutter.project_name}}/README.md
@@ -106,7 +106,7 @@ hello-world$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs18.x/hello-ts/{{cookiecutter.project_name}}/README.md
+++ b/nodejs18.x/hello-ts/{{cookiecutter.project_name}}/README.md
@@ -117,7 +117,7 @@ hello-world$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs18.x/hello/{{cookiecutter.project_name}}/README.md
+++ b/nodejs18.x/hello/{{cookiecutter.project_name}}/README.md
@@ -117,7 +117,7 @@ hello-world$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs18.x/s3/{{cookiecutter.project_name}}/README.md
+++ b/nodejs18.x/s3/{{cookiecutter.project_name}}/README.md
@@ -141,7 +141,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs18.x/scratch/{{cookiecutter.project_name}}/README.md
+++ b/nodejs18.x/scratch/{{cookiecutter.project_name}}/README.md
@@ -130,7 +130,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs18.x/sns/{{cookiecutter.project_name}}/README.md
+++ b/nodejs18.x/sns/{{cookiecutter.project_name}}/README.md
@@ -136,7 +136,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs18.x/sqs/{{cookiecutter.project_name}}/README.md
+++ b/nodejs18.x/sqs/{{cookiecutter.project_name}}/README.md
@@ -130,7 +130,7 @@ my-application$ npm run test
 To delete the sample application and the bucket that you created, use the AWS CLI.
 
 ```bash
-my-application$ aws cloudformation delete-stack --stack-name sam-app
+my-application$ sam delete --stack-name sam-app
 my-application$ aws s3 rb s3://BUCKET_NAME
 ```
 

--- a/nodejs18.x/step-func/{{cookiecutter.project_name}}/README.md
+++ b/nodejs18.x/step-func/{{cookiecutter.project_name}}/README.md
@@ -127,7 +127,7 @@ Check [`makefile`](./makefile) for details
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources

--- a/nodejs18.x/web/{{cookiecutter.project_name}}/README.md
+++ b/nodejs18.x/web/{{cookiecutter.project_name}}/README.md
@@ -150,7 +150,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-aws cloudformation delete-stack --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name {{ cookiecutter.project_name }}
 ```
 
 ## Resources


### PR DESCRIPTION
*Issue #:* #384

*Description of changes:*

I am dividing into multiple smaller PRs since these changes will touch many templates. Include in this PR:
* Nodejs templates

NOTE: unlike other templates, under SQS nodejs template there is this line

```
aws s3 rb s3://BUCKET_NAME
```
Can consider to remove this line to make it consistent with other templates(?)
