### PR TITLE
fix: Bump torchvision and added build tests

### DIFF
--- a/python3.10/apigw-pytorch/cookiecutter.json
+++ b/python3.10/apigw-pytorch/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "project_name": "digit_classifier",
-  "pytorch_version": "1.8.0",
-  "torchvision_version": "0.9.0",
+  "pytorch_version": "1.13.1",
+  "torchvision_version": "0.14.1",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [

--- a/python3.10/apigw-scikit/cookiecutter.json
+++ b/python3.10/apigw-scikit/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "digit_classifier",
-  "scikit_learn_version": "1.2.2",
+  "scikit_learn_version": "0.24.1",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [

--- a/python3.10/apigw-scikit/cookiecutter.json
+++ b/python3.10/apigw-scikit/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "digit_classifier",
-  "scikit_learn_version": "0.24.1",
+  "scikit_learn_version": "1.2.2",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [

--- a/python3.10/apigw-scikit/{{cookiecutter.project_name}}/app/Dockerfile
+++ b/python3.10/apigw-scikit/{{cookiecutter.project_name}}/app/Dockerfile
@@ -3,6 +3,9 @@ FROM public.ecr.aws/lambda/python:3.10
 COPY app.py requirements.txt ./
 COPY model /opt/ml/model
 
+# temporarily install gcc so that scikit-learn can be built
+RUN yum install gcc -y
+
 RUN python3.10 -m pip install -r requirements.txt -t .
 
 CMD ["app.lambda_handler"]

--- a/python3.10/apigw-scikit/{{cookiecutter.project_name}}/app/Dockerfile
+++ b/python3.10/apigw-scikit/{{cookiecutter.project_name}}/app/Dockerfile
@@ -4,7 +4,7 @@ COPY app.py requirements.txt ./
 COPY model /opt/ml/model
 
 # temporarily install gcc so that scikit-learn can be built
-RUN yum install gcc -y
+RUN yum install gcc-c++ -y
 
 RUN python3.10 -m pip install -r requirements.txt -t .
 

--- a/python3.8/apigw-pytorch/cookiecutter.json
+++ b/python3.8/apigw-pytorch/cookiecutter.json
@@ -1,6 +1,8 @@
 {
   "project_name": "digit_classifier",
   "api_path": "/classify_digit",
+  "pytorch_version": "1.13.1",
+  "torchvision_version": "0.14.1",
   "architectures": {
     "value": [
       "x86_64"

--- a/python3.8/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.8/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
 -f https://download.pytorch.org/whl/torch_stable.html
-torch==1.13.1+cpu
-torchvision==0.9.0+cpu
+torch=={{cookiecutter.pytorch_version}}+cpu
+torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow==9.3.0

--- a/python3.9/apigw-pytorch/cookiecutter.json
+++ b/python3.9/apigw-pytorch/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "project_name": "digit_classifier",
   "pytorch_version": "1.13.1",
-  "torchvision_version": "0.9.0",
+  "torchvision_version": "0.14.1",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [

--- a/tests/integration/build_invoke/python/test_python_3_10.py
+++ b/tests/integration/build_invoke/python/test_python_3_10.py
@@ -65,3 +65,23 @@ class BuildInvoke_image_python3_10_cookiecutter_aws_sam_hello_python_lambda_imag
     directory = "python3.10/hello-img"
     # TODO: remove the line remove once python3.10 is GA
     should_test_lint = False
+
+class BuildInvoke_python3_10_pytorch(BuildInvokeBase.BuildInvokeBase):
+    directory = "python3.10/apigw-pytorch"
+    # TODO: remove the line remove once python3.10 is GA
+    should_test_lint = False
+
+class BuildInvoke_python3_10_scikit(BuildInvokeBase.BuildInvokeBase):
+    directory = "python3.10/apigw-scikit"
+    # TODO: remove the line remove once python3.10 is GA
+    should_test_lint = False
+
+class BuildInvoke_python3_10_tensorflow(BuildInvokeBase.BuildInvokeBase):
+    directory = "python3.10/apigw-tensorflow"
+    # TODO: remove the line remove once python3.10 is GA
+    should_test_lint = False
+
+class BuildInvoke_python3_10_xgboost(BuildInvokeBase.BuildInvokeBase):
+    directory = "python3.10/apigw-xgboost"
+    # TODO: remove the line remove once python3.10 is GA
+    should_test_lint = False

--- a/tests/integration/build_invoke/python/test_python_3_8.py
+++ b/tests/integration/build_invoke/python/test_python_3_8.py
@@ -45,3 +45,15 @@ class BuildInvoke_image_python3_8_cookiecutter_aws_sam_hello_python_lambda_image
 
 class BuildInvoke_python3_8_cookiecutter_aws_sam_hello_pt_python(BuildInvokeBase.SimpleHelloWorldBuildInvokeBase):
     directory = "python3.8/hello-pt"
+
+class BuildInvoke_python3_8_pytorch(BuildInvokeBase.BuildInvokeBase):
+    directory = "python3.8/apigw-pytorch"
+
+class BuildInvoke_python3_8_scikit(BuildInvokeBase.BuildInvokeBase):
+    directory = "python3.8/apigw-scikit"
+
+class BuildInvoke_python3_8_tensorflow(BuildInvokeBase.BuildInvokeBase):
+    directory = "python3.8/apigw-tensorflow"
+
+class BuildInvoke_python3_8_xgboost(BuildInvokeBase.BuildInvokeBase):
+    directory = "python3.8/apigw-xgboost"

--- a/tests/integration/build_invoke/python/test_python_3_9.py
+++ b/tests/integration/build_invoke/python/test_python_3_9.py
@@ -47,3 +47,14 @@ class BuildInvoke_image_python3_9_cookiecutter_aws_sam_hello_python_lambda_image
     BuildInvokeBase.SimpleHelloWorldBuildInvokeBase
 ):
     directory = "python3.9/hello-img"
+class BuildInvoke_python3_9_pytorch(BuildInvokeBase.BuildInvokeBase):
+    directory = "python3.9/apigw-pytorch"
+
+class BuildInvoke_python3_9_scikit(BuildInvokeBase.BuildInvokeBase):
+    directory = "python3.9/apigw-scikit"
+
+class BuildInvoke_python3_9_tensorflow(BuildInvokeBase.BuildInvokeBase):
+    directory = "python3.9/apigw-tensorflow"
+
+class BuildInvoke_python3_9_xgboost(BuildInvokeBase.BuildInvokeBase):
+    directory = "python3.9/apigw-xgboost"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The incorrect `torchvision` version was being used with pytorch. This also adds those templates to the build and invoke test suite.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
