### PR TITLE
Make bash scripts for Python 3.8 projects more consistent

### DIFF
--- a/python3.8/apigw-pytorch/cookiecutter.json
+++ b/python3.8/apigw-pytorch/cookiecutter.json
@@ -10,5 +10,6 @@
   },
   "_copy_without_render": [
     ".gitignore"
-  ]
+  ],
+  "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/apigw-pytorch/{{cookiecutter.project_name}}/README.md
+++ b/python3.8/apigw-pytorch/{{cookiecutter.project_name}}/README.md
@@ -89,7 +89,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-{{ cookiecutter.project_name }}$ sam logs -n InferenceFunction --stack-name {{ cookiecutter.project_name }} --tail
+{{ cookiecutter.project_name }}$ sam logs -n InferenceFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
@@ -99,7 +99,7 @@ You can find more information and examples about filtering Lambda function logs 
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 ## Resources

--- a/python3.8/apigw-scikit/cookiecutter.json
+++ b/python3.8/apigw-scikit/cookiecutter.json
@@ -8,5 +8,6 @@
   },
   "_copy_without_render": [
     ".gitignore"
-  ]
+  ],
+  "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/apigw-scikit/{{cookiecutter.project_name}}/README.md
+++ b/python3.8/apigw-scikit/{{cookiecutter.project_name}}/README.md
@@ -89,7 +89,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-{{ cookiecutter.project_name }}$ sam logs -n InferenceFunction --stack-name {{ cookiecutter.project_name }} --tail
+{{ cookiecutter.project_name }}$ sam logs -n InferenceFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
@@ -99,7 +99,7 @@ You can find more information and examples about filtering Lambda function logs 
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 ## Resources

--- a/python3.8/apigw-tensorflow/cookiecutter.json
+++ b/python3.8/apigw-tensorflow/cookiecutter.json
@@ -8,5 +8,6 @@
   },
   "_copy_without_render": [
     ".gitignore"
-  ]
+  ],
+  "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/apigw-tensorflow/{{cookiecutter.project_name}}/README.md
+++ b/python3.8/apigw-tensorflow/{{cookiecutter.project_name}}/README.md
@@ -89,7 +89,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-{{ cookiecutter.project_name }}$ sam logs -n InferenceFunction --stack-name {{ cookiecutter.project_name }} --tail
+{{ cookiecutter.project_name }}$ sam logs -n InferenceFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
@@ -99,7 +99,7 @@ You can find more information and examples about filtering Lambda function logs 
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 ## Resources

--- a/python3.8/apigw-xgboost/cookiecutter.json
+++ b/python3.8/apigw-xgboost/cookiecutter.json
@@ -8,5 +8,6 @@
   },
   "_copy_without_render": [
     ".gitignore"
-  ]
+  ],
+  "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/apigw-xgboost/{{cookiecutter.project_name}}/README.md
+++ b/python3.8/apigw-xgboost/{{cookiecutter.project_name}}/README.md
@@ -89,7 +89,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-{{ cookiecutter.project_name }}$ sam logs -n InferenceFunction --stack-name {{ cookiecutter.project_name }} --tail
+{{ cookiecutter.project_name }}$ sam logs -n InferenceFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
@@ -99,7 +99,7 @@ You can find more information and examples about filtering Lambda function logs 
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 ## Resources

--- a/python3.8/efs/cookiecutter.json
+++ b/python3.8/efs/cookiecutter.json
@@ -6,5 +6,6 @@
     },
     "_copy_without_render": [
         ".gitignore"
-    ]
+    ],
+    "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/efs/{{cookiecutter.project_name}}/README.md
+++ b/python3.8/efs/{{cookiecutter.project_name}}/README.md
@@ -59,7 +59,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-{{ cookiecutter.project_name }}$ sam logs -n HelloEfsFunction --stack-name {{ cookiecutter.project_name }} --tail
+{{ cookiecutter.project_name }}$ sam logs -n HelloEfsFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
@@ -74,7 +74,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 {{ cookiecutter.project_name }}$ python -m pytest tests/unit -v
 # integration test, requiring deploying the stack first.
 # Create the env variable AWS_SAM_STACK_NAME with the name of the stack we are testing
-{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME=<stack-name> python -m pytest tests/integration -v
+{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME="{{ cookiecutter.__stack_name }}" python -m pytest tests/integration -v
 ```
 
 ## Cleanup
@@ -82,7 +82,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 ## Resources

--- a/python3.8/event-bridge-schema/cookiecutter.json
+++ b/python3.8/event-bridge-schema/cookiecutter.json
@@ -12,5 +12,6 @@
     "AWS_Schema_detail_type": "EC2 Instance State-change Notification",
     "_copy_without_render": [
         ".gitignore"
-    ]
+    ],
+    "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/event-bridge-schema/{{cookiecutter.project_name}}/README.md
+++ b/python3.8/event-bridge-schema/{{cookiecutter.project_name}}/README.md
@@ -92,7 +92,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-{{ cookiecutter.project_name }}$ sam logs -n HelloWorldFunction --stack-name {{ cookiecutter.project_name }} --tail
+{{ cookiecutter.project_name }}$ sam logs -n HelloWorldFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
@@ -111,7 +111,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 To delete the sample application that you created, use the SAM CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 

--- a/python3.8/event-bridge/cookiecutter.json
+++ b/python3.8/event-bridge/cookiecutter.json
@@ -6,5 +6,6 @@
     },
     "_copy_without_render": [
         ".gitignore"
-    ]
+    ],
+    "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/event-bridge/{{cookiecutter.project_name}}/README.md
+++ b/python3.8/event-bridge/{{cookiecutter.project_name}}/README.md
@@ -91,7 +91,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-{{ cookiecutter.project_name }}$ sam logs -n HelloWorldFunction --stack-name {{ cookiecutter.project_name }} --tail
+{{ cookiecutter.project_name }}$ sam logs -n HelloWorldFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
@@ -106,7 +106,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 {{ cookiecutter.project_name }}$ python -m pytest tests/unit -v
 # integration test, requiring deploying the stack first.
 # Create the env variable AWS_SAM_STACK_NAME with the name of the stack we are testing
-{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME=<stack-name> python -m pytest tests/integration -v
+{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME="{{ cookiecutter.__stack_name }}" python -m pytest tests/integration -v
 ```
 
 ## Cleanup
@@ -114,7 +114,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 To delete the sample application that you created, use the SAM CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 ## Resources

--- a/python3.8/hello-img/cookiecutter.json
+++ b/python3.8/hello-img/cookiecutter.json
@@ -6,5 +6,6 @@
     },
     "_copy_without_render": [
         ".gitignore"
-    ]
+    ],
+    "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/hello-img/{{cookiecutter.project_name}}/README.md
+++ b/python3.8/hello-img/{{cookiecutter.project_name}}/README.md
@@ -84,7 +84,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-{{ cookiecutter.project_name }}$ sam logs -n HelloWorldFunction --stack-name {{ cookiecutter.project_name }} --tail
+{{ cookiecutter.project_name }}$ sam logs -n HelloWorldFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
@@ -103,7 +103,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 ## Resources

--- a/python3.8/hello-pt/cookiecutter.json
+++ b/python3.8/hello-pt/cookiecutter.json
@@ -9,5 +9,6 @@
     "Powertools Tracing": ["enabled","disabled"],
     "_copy_without_render": [
         ".gitignore"
-    ]
+    ],
+    "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/hello-pt/{{ cookiecutter.project_name }}/README.md
+++ b/python3.8/hello-pt/{{ cookiecutter.project_name }}/README.md
@@ -130,7 +130,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-{{ cookiecutter.project_name }}$ sam logs -n HelloWorldFunction --stack-name {{ cookiecutter.project_name }} --tail
+{{ cookiecutter.project_name }}$ sam logs -n HelloWorldFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
@@ -145,7 +145,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 {{ cookiecutter.project_name }}$ python -m pytest tests/unit -v
 # integration test, requiring deploying the stack first.
 # Create the env variable AWS_SAM_STACK_NAME with the name of the stack we are testing
-{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME=<stack-name> python -m pytest tests/integration -v
+{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME="{{ cookiecutter.__stack_name }}" python -m pytest tests/integration -v
 ```
 
 ### Cleanup
@@ -153,7 +153,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 ## Resources

--- a/python3.8/hello/cookiecutter.json
+++ b/python3.8/hello/cookiecutter.json
@@ -6,5 +6,6 @@
     },
     "_copy_without_render": [
         ".gitignore"
-    ]
+    ],
+    "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/hello/{{cookiecutter.project_name}}/README.md
+++ b/python3.8/hello/{{cookiecutter.project_name}}/README.md
@@ -97,7 +97,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-{{ cookiecutter.project_name }}$ sam logs -n HelloWorldFunction --stack-name {{ cookiecutter.project_name }} --tail
+{{ cookiecutter.project_name }}$ sam logs -n HelloWorldFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
@@ -112,7 +112,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 {{ cookiecutter.project_name }}$ python -m pytest tests/unit -v
 # integration test, requiring deploying the stack first.
 # Create the env variable AWS_SAM_STACK_NAME with the name of the stack we are testing
-{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME=<stack-name> python -m pytest tests/integration -v
+{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME="{{ cookiecutter.__stack_name }}" python -m pytest tests/integration -v
 ```
 
 ## Cleanup
@@ -120,7 +120,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 ## Resources

--- a/python3.8/step-func-conn/cookiecutter.json
+++ b/python3.8/step-func-conn/cookiecutter.json
@@ -6,5 +6,6 @@
     },
     "_copy_without_render": [
         ".gitignore"
-    ]
+    ],
+    "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/step-func-conn/{{cookiecutter.project_name}}/README.md
+++ b/python3.8/step-func-conn/{{cookiecutter.project_name}}/README.md
@@ -74,7 +74,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-{{ cookiecutter.project_name }}$ sam logs -n StockCheckerFunction --stack-name {{ cookiecutter.project_name }} --tail
+{{ cookiecutter.project_name }}$ sam logs -n StockCheckerFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
@@ -89,7 +89,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 {{ cookiecutter.project_name }}$ python -m pytest tests/unit -v
 # integration test, requiring deploying the stack first.
 # Create the env variable AWS_SAM_STACK_NAME with the name of the stack we are testing
-{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME=<stack-name> python -m pytest tests/integration -v
+{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME="{{ cookiecutter.__stack_name }}" python -m pytest tests/integration -v
 ```
 
 ## Cleanup
@@ -97,7 +97,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 ## Resources

--- a/python3.8/step-func/cookiecutter.json
+++ b/python3.8/step-func/cookiecutter.json
@@ -6,5 +6,6 @@
     },
     "_copy_without_render": [
         ".gitignore"
-    ]
+    ],
+    "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/step-func/{{cookiecutter.project_name}}/README.md
+++ b/python3.8/step-func/{{cookiecutter.project_name}}/README.md
@@ -74,7 +74,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-{{ cookiecutter.project_name }}$ sam logs -n StockCheckerFunction --stack-name {{ cookiecutter.project_name }} --tail
+{{ cookiecutter.project_name }}$ sam logs -n StockCheckerFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
@@ -89,7 +89,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 {{ cookiecutter.project_name }}$ python -m pytest tests/unit -v
 # integration test, requiring deploying the stack first.
 # Create the env variable AWS_SAM_STACK_NAME with the name of the stack we are testing
-{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME=<stack-name> python -m pytest tests/integration -v
+{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME="{{ cookiecutter.__stack_name }}" python -m pytest tests/integration -v
 ```
 
 ## Cleanup
@@ -97,7 +97,7 @@ Tests are defined in the `tests` folder in this project. Use PIP to install the 
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 ## Resources

--- a/python3.8/web-conn/cookiecutter.json
+++ b/python3.8/web-conn/cookiecutter.json
@@ -6,5 +6,6 @@
     },
     "_copy_without_render": [
         ".gitignore"
-    ]
+    ],
+    "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
 }

--- a/python3.8/web-conn/{{cookiecutter.project_name}}/README.md
+++ b/python3.8/web-conn/{{cookiecutter.project_name}}/README.md
@@ -58,7 +58,7 @@ The API Gateway endpoint API will be displayed in the outputs when the deploymen
 Build your application by using the `sam build` command.
 
 ```bash
-my-application$ sam build
+{{ cookiecutter.project_name }}$ sam build
 ```
 
 The AWS SAM CLI installs dependencies that are defined in `package.json`, creates a deployment package, and saves it in the `.aws-sam/build` folder.
@@ -68,15 +68,15 @@ Test a single function by invoking it directly with a test event. An event is a 
 Run functions locally and invoke them with the `sam local invoke` command.
 
 ```bash
-my-application$ sam local invoke putItemFunction --event events/event-post-item.json
-my-application$ sam local invoke getAllItemsFunction --event events/event-get-all-items.json
+{{ cookiecutter.project_name }}$ sam local invoke putItemFunction --event events/event-post-item.json
+{{ cookiecutter.project_name }}$ sam local invoke getAllItemsFunction --event events/event-get-all-items.json
 ```
 
 The AWS SAM CLI can also emulate your application's API. Use the `sam local start-api` command to run the API locally on port 3000.
 
 ```bash
-my-application$ sam local start-api
-my-application$ curl http://localhost:3000/
+{{ cookiecutter.project_name }}$ sam local start-api
+{{ cookiecutter.project_name }}$ curl http://localhost:3000/
 ```
 
 The AWS SAM CLI reads the application template to determine the API's routes and the functions that they invoke. The `Events` property on each function's definition includes the route and method for each path.
@@ -117,7 +117,7 @@ The dead-letter queue is a location for Lambda to send events that could not be 
 Deploy the updated application.
 
 ```bash
-my-application$ sam deploy
+{{ cookiecutter.project_name }}$ sam deploy
 ```
 
 Open the [**Applications**](https://console.aws.amazon.com/lambda/home#/applications) page of the Lambda console, and choose your application. When the deployment completes, view the application resources on the **Overview** tab to see the new resource. Then, choose the function to see the updated configuration that specifies the dead-letter queue.
@@ -129,7 +129,7 @@ To simplify troubleshooting, the AWS SAM CLI has a command called `sam logs`. `s
 **NOTE:** This command works for all Lambda functions, not just the ones you deploy using AWS SAM.
 
 ```bash
-my-application$ sam logs -n putItemFunction --stack-name sam-app --tail
+{{ cookiecutter.project_name }}$ sam logs -n putItemFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail
 ```
 
 **NOTE:** This uses the logical name of the function within the stack. This is the correct name to use when searching logs inside an AWS Lambda function within a CloudFormation stack, even if the deployed function name varies due to CloudFormation's unique resource name generation.
@@ -141,8 +141,8 @@ You can find more information and examples about filtering Lambda function logs 
 Tests are defined in the `__tests__` folder in this project. Use `npm` to install the [Jest test framework](https://jestjs.io/) and run unit tests.
 
 ```bash
-my-application$ npm install
-my-application$ npm run test
+{{ cookiecutter.project_name }}$ npm install
+{{ cookiecutter.project_name }}$ npm run test
 ```
 
 ## Cleanup
@@ -150,7 +150,7 @@ my-application$ npm run test
 To delete the sample application that you created, use the AWS CLI. Assuming you used your project name for the stack name, you can run the following:
 
 ```bash
-sam delete --stack-name {{ cookiecutter.project_name }}
+sam delete --stack-name "{{ cookiecutter.__stack_name }}"
 ```
 
 ## Resources


### PR DESCRIPTION
*Issue:* Since this one is minor, I didn't create an issue for this

*Description of changes:*

Changes focus on making bash scripts in Python documentation more consistent. Separated from #385, similar to #406.

There are a few changes included in this PR:

1. Remove hard-coded folder names:

```bash
# Old:
my-application$ sam build

# New:
{{ cookiecutter.project_name }}$ sam build
```

2. Introduce a new private variable for stack name as it turns out wrapping stack name within double quote might not solve the problem of Project Name with white space

`cookiecutter.json`
```
{
    "project_name": "Name of the project",
    ....
    "__stack_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}"
}
```

For example, if the project name is 'Sam App', stack name will be 'sam-app'

Similar examples can be found in other templates:
* dotnet6/hello-ps/{{cookiecutter.project_name}}/README.md
* dotnetcore3.1/hello-ps/{{cookiecutter.project_name}}/README.md
* al2/rust/hello-ddb/cookiecutter.json
* al2/rust/hello/cookiecutter.json

4. Remove hard-coded stack name in some test scripts:

```bash
# Old:
{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME=<stack-name> python -m pytest tests/integration -v

# New:
{{ cookiecutter.project_name }}$ AWS_SAM_STACK_NAME="{{ cookiecutter.__stack_name }}" python -m pytest tests/integration -v
```

5. Using transformed stack name inside double quote to prevent issue with Project Name containing whitespace:

```bash
{{ cookiecutter.project_name }}$ sam logs -n InferenceFunction --stack-name "{{ cookiecutter.__stack_name }}" --tail

# and
sam delete --stack-name "{{ cookiecutter.__stack_name }}"
```


