### PR TITLE
Update dotnet6 Powertools template 1.2.0

### DIFF
--- a/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -12,13 +12,13 @@
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
     {%- if cookiecutter["Powertools Tracing"] == "enabled"%}
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.11.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.0.1" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.0" />
     {%- endif %}
     {%- if cookiecutter["Powertools Metrics"] == "enabled"%}
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.0.1" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.2.0" />
     {%- endif %}
     {%- if cookiecutter["Powertools Logging"] == "enabled"%}
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.0.1" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.0" />
     {%- endif %}
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update dotnet6 Powertools template 1.2.0

Logging and tracing to version 1.1.0
Metrics to version 1.2.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
