### PR TITLE
Update aws-lambda-java-core to v1.2.2

### DIFF
--- a/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -16,7 +16,7 @@ def junitVersion = providers.gradleProperty('junit.jupiter.version')
     .get()
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.0'
     implementation 'com.amazonaws:aws-lambda-java-runtime-interface-client:2.1.1'
     

--- a/al2/graalvm/11/maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/al2/graalvm/11/maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>

--- a/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -16,7 +16,7 @@ def junitVersion = providers.gradleProperty('junit.jupiter.version')
     .get()
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.0'
     implementation 'com.amazonaws:aws-lambda-java-runtime-interface-client:2.1.1'
     

--- a/al2/graalvm/17/maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/al2/graalvm/17/maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>

--- a/java11/event-bridge-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java11/event-bridge-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'

--- a/java11/event-bridge-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java11/event-bridge-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java11/event-bridge-schema-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
+++ b/java11/event-bridge-schema-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'

--- a/java11/event-bridge-schema-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
+++ b/java11/event-bridge-schema-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java11/hello-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java11/hello-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.0'
     testImplementation 'junit:junit:4.13.2'
 }

--- a/java11/hello-img-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java11/hello-img-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/java11/hello-img-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java11/hello-img-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>

--- a/java11/hello-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java11/hello-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>

--- a/java11/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java11/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/java11/step-func-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
+++ b/java11/step-func-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java11/step-func-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
+++ b/java11/step-func-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java11/step-func-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
+++ b/java11/step-func-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java11/step-func-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
+++ b/java11/step-func-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java11/step-func-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
+++ b/java11/step-func-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java11/step-func-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
+++ b/java11/step-func-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java17/event-bridge-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java17/event-bridge-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'

--- a/java17/event-bridge-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java17/event-bridge-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java17/event-bridge-schema-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
+++ b/java17/event-bridge-schema-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'

--- a/java17/event-bridge-schema-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
+++ b/java17/event-bridge-schema-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java17/hello-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java17/hello-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.0'
     testImplementation 'junit:junit:4.13.2'
 }

--- a/java17/hello-img-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java17/hello-img-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/java17/hello-img-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java17/hello-img-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>

--- a/java17/hello-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java17/hello-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>

--- a/java17/hello-pt-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java17/hello-pt-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.0'

--- a/java17/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java17/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/java17/step-func-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
+++ b/java17/step-func-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java17/step-func-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
+++ b/java17/step-func-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java17/step-func-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
+++ b/java17/step-func-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java17/step-func-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
+++ b/java17/step-func-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java17/step-func-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
+++ b/java17/step-func-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java17/step-func-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
+++ b/java17/step-func-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java8.al2/event-bridge-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8.al2/event-bridge-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'

--- a/java8.al2/event-bridge-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8.al2/event-bridge-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java8.al2/event-bridge-schema-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
+++ b/java8.al2/event-bridge-schema-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'

--- a/java8.al2/event-bridge-schema-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
+++ b/java8.al2/event-bridge-schema-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java8.al2/hello-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8.al2/hello-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java8.al2/hello-img-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8.al2/hello-img-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/java8.al2/hello-img-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8.al2/hello-img-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>

--- a/java8.al2/hello-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8.al2/hello-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java8.al2/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8.al2/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/java8.al2/step-func-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
+++ b/java8.al2/step-func-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java8.al2/step-func-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
+++ b/java8.al2/step-func-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java8.al2/step-func-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
+++ b/java8.al2/step-func-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java8.al2/step-func-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
+++ b/java8.al2/step-func-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java8.al2/step-func-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
+++ b/java8.al2/step-func-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java8.al2/step-func-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
+++ b/java8.al2/step-func-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java8/event-bridge-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8/event-bridge-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'

--- a/java8/event-bridge-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8/event-bridge-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java8/event-bridge-schema-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
+++ b/java8/event-bridge-schema-gradle/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'

--- a/java8/event-bridge-schema-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
+++ b/java8/event-bridge-schema-maven/{{cookiecutter.project_name}}/{{cookiecutter.function_name}}/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java8/hello-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8/hello-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.0'
     testImplementation 'junit:junit:4.13.2'
 }

--- a/java8/hello-img-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/java8/hello-img-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.amazonaws:aws-lambda-java-events:3.11.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/java8/hello-img-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8/hello-img-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>

--- a/java8/hello-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8/hello-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>com.amazonaws</groupId>

--- a/java8/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
+++ b/java8/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/java8/step-func-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
+++ b/java8/step-func-gradle/{{cookiecutter.project_name}}/functions/StockBuyer/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java8/step-func-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
+++ b/java8/step-func-gradle/{{cookiecutter.project_name}}/functions/StockChecker/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java8/step-func-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
+++ b/java8/step-func-gradle/{{cookiecutter.project_name}}/functions/StockSeller/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/java8/step-func-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
+++ b/java8/step-func-maven/{{cookiecutter.project_name}}/functions/StockBuyer/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java8/step-func-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
+++ b/java8/step-func-maven/{{cookiecutter.project_name}}/functions/StockChecker/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>

--- a/java8/step-func-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
+++ b/java8/step-func-maven/{{cookiecutter.project_name}}/functions/StockSeller/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>


### PR DESCRIPTION
*Description of changes:*
Update `aws-lambda-java-core` to `v1.2.2` which was released on `Nov 09, 2022`

Ref: https://mvnrepository.com/artifact/com.amazonaws/aws-lambda-java-core/1.2.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
