### PR TITLE
fix: Node.js Powertools Template Typo

### DIFF
--- a/nodejs18.x/hello-ts-pt/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs18.x/hello-ts-pt/{{cookiecutter.project_name}}/template.yaml
@@ -24,10 +24,10 @@ Resources:
         - {{arch}}
       {%- endfor %}
       {%- endif %}
-      {%- if cookiecutter["Powertools for AWS Lambda (TypeScript) for AWS Lambda (TypeScript) Tracing"] == "enabled"%}
+      {%- if cookiecutter["Powertools for AWS Lambda (TypeScript) Tracing"] == "enabled"%}
       Tracing: Active
       {%- endif %}
-      {%- if cookiecutter["Powertools for AWS Lambda (TypeScript) for AWS Lambda (TypeScript) Tracing"] == "enabled" or cookiecutter["Powertools for AWS Lambda (TypeScript) for AWS Lambda (TypeScript) Metrics"] == "enabled" or cookiecutter["Powertools for AWS Lambda (TypeScript) for AWS Lambda (TypeScript) Logging"] == "enabled" %}
+      {%- if cookiecutter["Powertools for AWS Lambda (TypeScript) Tracing"] == "enabled" or cookiecutter["Powertools for AWS Lambda (TypeScript) for AWS Lambda (TypeScript) Metrics"] == "enabled" or cookiecutter["Powertools for AWS Lambda (TypeScript) for AWS Lambda (TypeScript) Logging"] == "enabled" %}
       Environment:
         Variables:
           {%- if cookiecutter["Powertools for AWS Lambda (TypeScript) Tracing"] == "enabled" or cookiecutter["Powertools for AWS Lambda (TypeScript) Metrics"] == "enabled"%}

--- a/nodejs18.x/hello-ts-pt/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs18.x/hello-ts-pt/{{cookiecutter.project_name}}/template.yaml
@@ -27,7 +27,7 @@ Resources:
       {%- if cookiecutter["Powertools for AWS Lambda (TypeScript) Tracing"] == "enabled"%}
       Tracing: Active
       {%- endif %}
-      {%- if cookiecutter["Powertools for AWS Lambda (TypeScript) Tracing"] == "enabled" or cookiecutter["Powertools for AWS Lambda (TypeScript) for AWS Lambda (TypeScript) Metrics"] == "enabled" or cookiecutter["Powertools for AWS Lambda (TypeScript) for AWS Lambda (TypeScript) Logging"] == "enabled" %}
+      {%- if cookiecutter["Powertools for AWS Lambda (TypeScript) Tracing"] == "enabled" or cookiecutter["Powertools for AWS Lambda (TypeScript) Metrics"] == "enabled" or cookiecutter["Powertools for AWS Lambda (TypeScript) Logging"] == "enabled" %}
       Environment:
         Variables:
           {%- if cookiecutter["Powertools for AWS Lambda (TypeScript) Tracing"] == "enabled" or cookiecutter["Powertools for AWS Lambda (TypeScript) Metrics"] == "enabled"%}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/5319

*Description of changes:*
Typo in the cookiecutter template results in `sam init` crashing when attempting to resolve the template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
