### PR TITLE
Update the Go Hello-World Example

### DIFF
--- a/al2/go/hello-img/tests/test_bake_project.py
+++ b/al2/go/hello-img/tests/test_bake_project.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 
 import os
-import subprocess
 
 
 @contextmanager
@@ -40,8 +39,8 @@ def test_app_content(cookies):
 
     contents = (
         "github.com/aws/aws-lambda-go/events",
-        "resp, err := http.Get(DefaultHTTPGetAddress)",
-        "lambda.Start(handler)",
+        "sourceIP := request.RequestContext.Identity.SourceIP",
+        "lambda.Start(handler)"
     )
 
     for content in contents:
@@ -55,9 +54,9 @@ def test_app_test_content(cookies):
     app_content = "".join(app_content)
 
     contents = (
-        'DefaultHTTPGetAddress = "http://127.0.0.1:12345"',
-        "DefaultHTTPGetAddress = ts.URL",
-        "Successful Request",
+        "func TestHandler(t *testing.T)",
+        "SourceIP: \"127.0.0.1\"",
+        "response, err := handler(testCase.request)"
     )
 
     for content in contents:

--- a/al2/go/hello-img/{{cookiecutter.project_name}}/README.md
+++ b/al2/go/hello-img/{{cookiecutter.project_name}}/README.md
@@ -84,7 +84,8 @@ You can find your API Gateway Endpoint URL in the output values displayed after 
 We use `testing` package that is built-in in Golang and you can simply run the following command to run our tests locally:
 
 ```shell
-go test -v ./hello-world/
+cd ./hello-world/
+go test -v .
 ```
 # Appendix
 

--- a/al2/go/hello-img/{{cookiecutter.project_name}}/hello-world/main.go
+++ b/al2/go/hello-img/{{cookiecutter.project_name}}/hello-world/main.go
@@ -1,47 +1,24 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"io"
-	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
-var (
-	// DefaultHTTPGetAddress Default Address
-	DefaultHTTPGetAddress = "https://checkip.amazonaws.com"
-
-	// ErrNoIP No IP found in response
-	ErrNoIP = errors.New("No IP in HTTP response")
-
-	// ErrNon200Response non 200 status code in response
-	ErrNon200Response = errors.New("Non 200 Response found")
-)
-
 func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	resp, err := http.Get(DefaultHTTPGetAddress)
-	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
-	}
+	var greeting string
+	sourceIP := request.RequestContext.Identity.SourceIP
 
-	if resp.StatusCode != 200 {
-		return events.APIGatewayProxyResponse{}, ErrNon200Response
-	}
-
-	ip, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
-	}
-
-	if len(ip) == 0 {
-		return events.APIGatewayProxyResponse{}, ErrNoIP
+	if sourceIP == "" {
+		greeting = "Hello, world!\n"
+	} else {
+		greeting = fmt.Sprintf("Hello, %s!\n", sourceIP)
 	}
 
 	return events.APIGatewayProxyResponse{
-		Body:       fmt.Sprintf("Hello, %v", string(ip)),
+		Body:       greeting,
 		StatusCode: 200,
 	}, nil
 }

--- a/al2/go/hello/tests/test_bake_project.py
+++ b/al2/go/hello/tests/test_bake_project.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 
 import os
-import subprocess
 
 
 @contextmanager
@@ -40,7 +39,7 @@ def test_app_content(cookies):
 
     contents = (
         "github.com/aws/aws-lambda-go/events",
-        "resp, err := http.Get(DefaultHTTPGetAddress)",
+        "sourceIP := request.RequestContext.Identity.SourceIP",
         "lambda.Start(handler)"
     )
 
@@ -55,9 +54,9 @@ def test_app_test_content(cookies):
     app_content = ''.join(app_content)
 
     contents = (
-        "DefaultHTTPGetAddress = \"http://127.0.0.1:12345\"",
-        "DefaultHTTPGetAddress = ts.URL",
-        "Successful Request"
+        "func TestHandler(t *testing.T)",
+        "SourceIP: \"127.0.0.1\"",
+        "response, err := handler(testCase.request)"
     )
 
     for content in contents:

--- a/al2/go/hello/{{cookiecutter.project_name}}/README.md
+++ b/al2/go/hello/{{cookiecutter.project_name}}/README.md
@@ -88,7 +88,8 @@ You can find your API Gateway Endpoint URL in the output values displayed after 
 We use `testing` package that is built-in in Golang and you can simply run the following command to run our tests:
 
 ```shell
-go test -v ./hello-world/
+cd ./hello-world/
+go test -v .
 ```
 # Appendix
 

--- a/al2/go/hello/{{cookiecutter.project_name}}/hello-world/main.go
+++ b/al2/go/hello/{{cookiecutter.project_name}}/hello-world/main.go
@@ -1,47 +1,24 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"io"
-	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
-var (
-	// DefaultHTTPGetAddress Default Address
-	DefaultHTTPGetAddress = "https://checkip.amazonaws.com"
-
-	// ErrNoIP No IP found in response
-	ErrNoIP = errors.New("No IP in HTTP response")
-
-	// ErrNon200Response non 200 status code in response
-	ErrNon200Response = errors.New("Non 200 Response found")
-)
-
 func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	resp, err := http.Get(DefaultHTTPGetAddress)
-	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
-	}
+	var greeting string
+	sourceIP := request.RequestContext.Identity.SourceIP
 
-	if resp.StatusCode != 200 {
-		return events.APIGatewayProxyResponse{}, ErrNon200Response
-	}
-
-	ip, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
-	}
-
-	if len(ip) == 0 {
-		return events.APIGatewayProxyResponse{}, ErrNoIP
+	if sourceIP == "" {
+		greeting = "Hello, world!\n"
+	} else {
+		greeting = fmt.Sprintf("Hello, %s!\n", sourceIP)
 	}
 
 	return events.APIGatewayProxyResponse{
-		Body:       fmt.Sprintf("Hello, %v", string(ip)),
+		Body:       greeting,
 		StatusCode: 200,
 	}, nil
 }

--- a/go1.x/hello-img/tests/test_bake_project.py
+++ b/go1.x/hello-img/tests/test_bake_project.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 
 import os
-import subprocess
 
 
 @contextmanager
@@ -40,8 +39,8 @@ def test_app_content(cookies):
 
     contents = (
         "github.com/aws/aws-lambda-go/events",
-        "resp, err := http.Get(DefaultHTTPGetAddress)",
-        "lambda.Start(handler)",
+        "sourceIP := request.RequestContext.Identity.SourceIP",
+        "lambda.Start(handler)"
     )
 
     for content in contents:
@@ -55,9 +54,9 @@ def test_app_test_content(cookies):
     app_content = "".join(app_content)
 
     contents = (
-        'DefaultHTTPGetAddress = "http://127.0.0.1:12345"',
-        "DefaultHTTPGetAddress = ts.URL",
-        "Successful Request",
+        "func TestHandler(t *testing.T)",
+        "SourceIP: \"127.0.0.1\"",
+        "response, err := handler(testCase.request)"
     )
 
     for content in contents:

--- a/go1.x/hello-img/{{cookiecutter.project_name}}/README.md
+++ b/go1.x/hello-img/{{cookiecutter.project_name}}/README.md
@@ -84,7 +84,8 @@ You can find your API Gateway Endpoint URL in the output values displayed after 
 We use `testing` package that is built-in in Golang and you can simply run the following command to run our tests locally:
 
 ```shell
-go test -v ./hello-world/
+cd ./hello-world/
+go test -v .
 ```
 # Appendix
 

--- a/go1.x/hello-img/{{cookiecutter.project_name}}/hello-world/main.go
+++ b/go1.x/hello-img/{{cookiecutter.project_name}}/hello-world/main.go
@@ -1,47 +1,24 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"io"
-	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
-var (
-	// DefaultHTTPGetAddress Default Address
-	DefaultHTTPGetAddress = "https://checkip.amazonaws.com"
-
-	// ErrNoIP No IP found in response
-	ErrNoIP = errors.New("No IP in HTTP response")
-
-	// ErrNon200Response non 200 status code in response
-	ErrNon200Response = errors.New("Non 200 Response found")
-)
-
 func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	resp, err := http.Get(DefaultHTTPGetAddress)
-	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
-	}
+	var greeting string
+	sourceIP := request.RequestContext.Identity.SourceIP
 
-	if resp.StatusCode != 200 {
-		return events.APIGatewayProxyResponse{}, ErrNon200Response
-	}
-
-	ip, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
-	}
-
-	if len(ip) == 0 {
-		return events.APIGatewayProxyResponse{}, ErrNoIP
+	if sourceIP == "" {
+		greeting = "Hello, world!\n"
+	} else {
+		greeting = fmt.Sprintf("Hello, %s!\n", sourceIP)
 	}
 
 	return events.APIGatewayProxyResponse{
-		Body:       fmt.Sprintf("Hello, %v", string(ip)),
+		Body:       greeting,
 		StatusCode: 200,
 	}, nil
 }

--- a/go1.x/hello/tests/test_bake_project.py
+++ b/go1.x/hello/tests/test_bake_project.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 
 import os
-import subprocess
 
 
 @contextmanager
@@ -40,7 +39,7 @@ def test_app_content(cookies):
 
     contents = (
         "github.com/aws/aws-lambda-go/events",
-        "resp, err := http.Get(DefaultHTTPGetAddress)",
+        "sourceIP := request.RequestContext.Identity.SourceIP",
         "lambda.Start(handler)"
     )
 
@@ -55,9 +54,9 @@ def test_app_test_content(cookies):
     app_content = ''.join(app_content)
 
     contents = (
-        "DefaultHTTPGetAddress = \"http://127.0.0.1:12345\"",
-        "DefaultHTTPGetAddress = ts.URL",
-        "Successful Request"
+        "func TestHandler(t *testing.T)",
+        "SourceIP: \"127.0.0.1\"",
+        "response, err := handler(testCase.request)"
     )
 
     for content in contents:

--- a/go1.x/hello/{{cookiecutter.project_name}}/README.md
+++ b/go1.x/hello/{{cookiecutter.project_name}}/README.md
@@ -88,7 +88,8 @@ You can find your API Gateway Endpoint URL in the output values displayed after 
 We use `testing` package that is built-in in Golang and you can simply run the following command to run our tests:
 
 ```shell
-go test -v ./hello-world/
+cd ./hello-world/
+go test -v .
 ```
 # Appendix
 

--- a/go1.x/hello/{{cookiecutter.project_name}}/hello-world/main.go
+++ b/go1.x/hello/{{cookiecutter.project_name}}/hello-world/main.go
@@ -1,47 +1,24 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"io"
-	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
-var (
-	// DefaultHTTPGetAddress Default Address
-	DefaultHTTPGetAddress = "https://checkip.amazonaws.com"
-
-	// ErrNoIP No IP found in response
-	ErrNoIP = errors.New("No IP in HTTP response")
-
-	// ErrNon200Response non 200 status code in response
-	ErrNon200Response = errors.New("Non 200 Response found")
-)
-
 func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	resp, err := http.Get(DefaultHTTPGetAddress)
-	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
-	}
+	var greeting string
+	sourceIP := request.RequestContext.Identity.SourceIP
 
-	if resp.StatusCode != 200 {
-		return events.APIGatewayProxyResponse{}, ErrNon200Response
-	}
-
-	ip, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
-	}
-
-	if len(ip) == 0 {
-		return events.APIGatewayProxyResponse{}, ErrNoIP
+	if sourceIP == "" {
+		greeting = "Hello, world!\n"
+	} else {
+		greeting = fmt.Sprintf("Hello, %s!\n", sourceIP)
 	}
 
 	return events.APIGatewayProxyResponse{
-		Body:       fmt.Sprintf("Hello, %v", string(ip)),
+		Body:       greeting,
 		StatusCode: 200,
 	}, nil
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli-app-templates/issues/421

*Description of changes:*
Update the Go hello-world example so that it does not rely on an external API call. The call to `https://checkip.amazonaws.com` would intermittently fail and result in unexpected errors. These changes simplify the example and get the requestor's IP from the request context.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
