### PR TITLE
chore: fix a non-readable syntax in python templates

### DIFF
--- a/python3.10/step-func-conn/{{cookiecutter.project_name}}/tests/unit/test_checker.py
+++ b/python3.10/step-func-conn/{{cookiecutter.project_name}}/tests/unit/test_checker.py
@@ -3,4 +3,4 @@ from functions.stock_checker import app
 
 def test_stock_checker():
     data = app.lambda_handler(None, "")
-    assert 0 <= data["stock_price"] > 0 <= 100
+    assert 0 <= data["stock_price"] <= 100

--- a/python3.10/step-func/{{cookiecutter.project_name}}/tests/unit/test_checker.py
+++ b/python3.10/step-func/{{cookiecutter.project_name}}/tests/unit/test_checker.py
@@ -3,4 +3,4 @@ from functions.stock_checker import app
 
 def test_stock_checker():
     data = app.lambda_handler(None, "")
-    assert 0 <= data["stock_price"] > 0 <= 100
+    assert 0 <= data["stock_price"] <= 100

--- a/python3.7/step-func-conn/{{cookiecutter.project_name}}/tests/unit/test_checker.py
+++ b/python3.7/step-func-conn/{{cookiecutter.project_name}}/tests/unit/test_checker.py
@@ -3,4 +3,4 @@ from functions.stock_checker import app
 
 def test_stock_checker():
     data = app.lambda_handler(None, "")
-    assert 0 <= data["stock_price"] > 0 <= 100
+    assert 0 <= data["stock_price"] <= 100

--- a/python3.7/step-func/{{cookiecutter.project_name}}/tests/unit/test_checker.py
+++ b/python3.7/step-func/{{cookiecutter.project_name}}/tests/unit/test_checker.py
@@ -3,4 +3,4 @@ from functions.stock_checker import app
 
 def test_stock_checker():
     data = app.lambda_handler(None, "")
-    assert 0 <= data["stock_price"] > 0 <= 100
+    assert 0 <= data["stock_price"] <= 100

--- a/python3.8/step-func-conn/{{cookiecutter.project_name}}/tests/unit/test_checker.py
+++ b/python3.8/step-func-conn/{{cookiecutter.project_name}}/tests/unit/test_checker.py
@@ -3,4 +3,4 @@ from functions.stock_checker import app
 
 def test_stock_checker():
     data = app.lambda_handler(None, "")
-    assert 0 <= data["stock_price"] > 0 <= 100
+    assert 0 <= data["stock_price"] <= 100

--- a/python3.8/step-func/{{cookiecutter.project_name}}/tests/unit/test_checker.py
+++ b/python3.8/step-func/{{cookiecutter.project_name}}/tests/unit/test_checker.py
@@ -3,4 +3,4 @@ from functions.stock_checker import app
 
 def test_stock_checker():
     data = app.lambda_handler(None, "")
-    assert 0 <= data["stock_price"] > 0 <= 100
+    assert 0 <= data["stock_price"] <= 100

--- a/python3.9/step-func-conn/{{cookiecutter.project_name}}/tests/unit/test_checker.py
+++ b/python3.9/step-func-conn/{{cookiecutter.project_name}}/tests/unit/test_checker.py
@@ -3,4 +3,4 @@ from functions.stock_checker import app
 
 def test_stock_checker():
     data = app.lambda_handler(None, "")
-    assert 0 <= data["stock_price"] > 0 <= 100
+    assert 0 <= data["stock_price"] <= 100

--- a/python3.9/step-func/{{cookiecutter.project_name}}/tests/unit/test_checker.py
+++ b/python3.9/step-func/{{cookiecutter.project_name}}/tests/unit/test_checker.py
@@ -3,4 +3,4 @@ from functions.stock_checker import app
 
 def test_stock_checker():
     data = app.lambda_handler(None, "")
-    assert 0 <= data["stock_price"] > 0 <= 100
+    assert 0 <= data["stock_price"] <= 100


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Changing `assert 0 <= data["stock_price"] > 0 <= 100` to `assert 0 <= data["stock_price"] <= 100` as the `> 0` part seems redundant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
