### PR TITLE
fix: Scikit learn installation

### DIFF
--- a/python3.10/apigw-scikit/cookiecutter.json
+++ b/python3.10/apigw-scikit/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "digit_classifier",
-  "scikit_learn_version": "0.24.1",
+  "scikit_learn_version": "1.3.0",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [

--- a/python3.11/apigw-scikit/cookiecutter.json
+++ b/python3.11/apigw-scikit/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "digit_classifier",
-  "scikit_learn_version": "0.24.1",
+  "scikit_learn_version": "1.3.0",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [

--- a/python3.8/apigw-scikit/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.8/apigw-scikit/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,2 +1,2 @@
-scikit-learn==0.23.2
+scikit-learn==1.3.0
 pillow==9.3.0

--- a/python3.9/apigw-scikit/cookiecutter.json
+++ b/python3.9/apigw-scikit/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "digit_classifier",
-  "scikit_learn_version": "0.24.1",
+  "scikit_learn_version": "1.3.0",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Updates outdated version of scikit-learn causing pip installations to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
