### PR TITLE
improvement: add class param to java powertools logger

### DIFF
--- a/java11/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/main/java/helloworld/App.java
+++ b/java11/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/main/java/helloworld/App.java
@@ -33,7 +33,7 @@ import static software.amazon.lambda.powertools.tracing.CaptureMode.*;
 public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     {%- if cookiecutter[ "Powertools for AWS Lambda (Java) Logging" ] == "enabled" %}
-    Logger log = LogManager.getLogger();
+    Logger log = LogManager.getLogger(App.class);
 
 
     @Logging(logEvent = true)

--- a/java17/hello-pt-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/src/main/java/helloworld/App.java
+++ b/java17/hello-pt-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/src/main/java/helloworld/App.java
@@ -33,7 +33,7 @@ import static software.amazon.lambda.powertools.tracing.CaptureMode.*;
 public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     {%- if cookiecutter[ "Powertools for AWS Lambda (Java) Logging" ] == "enabled" %}
-    Logger log = LogManager.getLogger();
+    Logger log = LogManager.getLogger(App.class);
 
 
     @Logging(logEvent = true)

--- a/java17/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/main/java/helloworld/App.java
+++ b/java17/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/main/java/helloworld/App.java
@@ -33,7 +33,7 @@ import static software.amazon.lambda.powertools.tracing.CaptureMode.*;
 public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     {%- if cookiecutter[ "Powertools for AWS Lambda (Java) Logging" ] == "enabled" %}
-    Logger log = LogManager.getLogger();
+    Logger log = LogManager.getLogger(App.class);
 
 
     @Logging(logEvent = true)

--- a/java8.al2/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/main/java/helloworld/App.java
+++ b/java8.al2/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/main/java/helloworld/App.java
@@ -33,7 +33,7 @@ import static software.amazon.lambda.powertools.tracing.CaptureMode.*;
 public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     {%- if cookiecutter[ "Powertools for AWS Lambda (Java) Logging" ] == "enabled" %}
-    Logger log = LogManager.getLogger();
+    Logger log = LogManager.getLogger(App.class);
 
 
     @Logging(logEvent = true)

--- a/java8/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/main/java/helloworld/App.java
+++ b/java8/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/main/java/helloworld/App.java
@@ -33,7 +33,7 @@ import static software.amazon.lambda.powertools.tracing.CaptureMode.*;
 public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     {%- if cookiecutter[ "Powertools for AWS Lambda (Java) Logging" ] == "enabled" %}
-    Logger log = LogManager.getLogger(App.clas);
+    Logger log = LogManager.getLogger(App.class);
 
 
     @Logging(logEvent = true)

--- a/java8/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/main/java/helloworld/App.java
+++ b/java8/hello-pt-maven/{{cookiecutter.project_name}}/HelloWorldFunction/src/main/java/helloworld/App.java
@@ -33,7 +33,7 @@ import static software.amazon.lambda.powertools.tracing.CaptureMode.*;
 public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     {%- if cookiecutter[ "Powertools for AWS Lambda (Java) Logging" ] == "enabled" %}
-    Logger log = LogManager.getLogger();
+    Logger log = LogManager.getLogger(App.clas);
 
 
     @Logging(logEvent = true)


### PR DESCRIPTION
*Issue #, if available:* closes #366

*Description of changes:*
This PR adds an explicit parameter `App.class` to the Powertools for AWS Lambda (Java) Logger class. When troubleshooting the dependencies between SAM and CDK bundling we found out that this was the crucial part. To keep the code consistent between CDK and SAM examples we propose to add an explicit param. 

@jeromevdl wrote an extensive [blog post](https://awstip.com/packaging-deploying-java11-based-lambda-functions-19c456e062a9) diving deep into this issue 

I can't believe I missed to close this issue back in March, sorry about that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
