### PR TITLE
Fix Powertools Init Template Naming

### DIFF
--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -1110,11 +1110,11 @@
     },
     {
       "directory": "python3.11/hello-pt",
-      "displayName": "Hello World Example With Powertools",
+      "displayName": "Hello World Example With Powertools for AWS Lambda",
       "dependencyManager": "pip",
       "appTemplate": "hello-world-powertools-python",
       "packageType": "Zip",
-      "useCaseName": "Hello World Example With Powertools"
+      "useCaseName": "Hello World Example With Powertools for AWS Lambda"
     },
     {
       "directory": "python3.11/event-bridge",


### PR DESCRIPTION
Powertools init templates have inconsistent examples causing a confusing display screen for identical templates.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
