### PR TITLE
fix: enable encryption and versioning for S3 buckets defined in app templates

### DIFF
--- a/dotnet6/s3/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet6/s3/{{cookiecutter.project_name}}/template.yaml
@@ -41,6 +41,11 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref AppBucketName
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - BucketKeyEnabled: true
+      VersioningConfiguration:
+        Status: Enabled
 
 Outputs:
   AppBucketArn:

--- a/nodejs14.x/s3/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs14.x/s3/{{cookiecutter.project_name}}/template.yaml
@@ -40,3 +40,8 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref AppBucketName
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - BucketKeyEnabled: true
+      VersioningConfiguration:
+        Status: Enabled

--- a/nodejs16.x/s3/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs16.x/s3/{{cookiecutter.project_name}}/template.yaml
@@ -40,3 +40,8 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref AppBucketName
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - BucketKeyEnabled: true
+      VersioningConfiguration:
+        Status: Enabled

--- a/nodejs18.x/full-stack/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs18.x/full-stack/{{cookiecutter.project_name}}/template.yaml
@@ -151,6 +151,12 @@ Resources:
   # S3 Bucket to host single page app website
   WebSiteBucket:
     Type: "AWS::S3::Bucket"
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - BucketKeyEnabled: true
+      VersioningConfiguration:
+        Status: Enabled
   WebSiteBucketPolicy:
     Type: "AWS::S3::BucketPolicy"
     Properties:

--- a/nodejs18.x/s3/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs18.x/s3/{{cookiecutter.project_name}}/template.yaml
@@ -40,3 +40,8 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Ref AppBucketName
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - BucketKeyEnabled: true
+      VersioningConfiguration:
+        Status: Enabled


### PR DESCRIPTION
Enable Encryption and Versioning for S3 Bucket resources defined in SAM CLI Templates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
