### PR TITLE
chore: Update Powertools dotnet6 template v1.7.0

### DIFF
--- a/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/Function.cs
+++ b/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/Function.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.APIGatewayEvents;
 {%- if cookiecutter["Powertools for AWS Lambda (.NET) Tracing"] == "enabled"%}
-using Amazon.XRay.Recorder.Handlers.AwsSdk;
 using AWS.Lambda.Powertools.Tracing;
 {%- endif %}
 {%- if cookiecutter["Powertools for AWS Lambda (.NET) Metrics"] == "enabled"%}
@@ -29,7 +28,7 @@ namespace HelloWorld
         {%- if cookiecutter["Powertools for AWS Lambda (.NET) Tracing"] == "enabled"%}
         public Function()
         {
-            AWSSDKHandler.RegisterXRayForAllServices();
+            Tracing.RegisterForAllServices();
         }
         {%- endif %}
   

--- a/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
     {%- if cookiecutter["Powertools for AWS Lambda (.NET) Tracing"] == "enabled"%}
-    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.11.0" />
     <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.3.0" />
     {%- endif %}
     {%- if cookiecutter["Powertools for AWS Lambda (.NET) Metrics"] == "enabled"%}

--- a/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -8,17 +8,17 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
     {%- if cookiecutter["Powertools for AWS Lambda (.NET) Tracing"] == "enabled"%}
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.11.0" />
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.3.0" />
     {%- endif %}
     {%- if cookiecutter["Powertools for AWS Lambda (.NET) Metrics"] == "enabled"%}
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.2.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.4.0" />
     {%- endif %}
     {%- if cookiecutter["Powertools for AWS Lambda (.NET) Logging"] == "enabled"%}
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.3.0" />
     {%- endif %}
   </ItemGroup>
 </Project>

--- a/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
     {%- if cookiecutter["Powertools for AWS Lambda (.NET) Tracing"] == "enabled"%}
-    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.12.0" />
+    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.11.0" />
     <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.3.0" />
     {%- endif %}
     {%- if cookiecutter["Powertools for AWS Lambda (.NET) Metrics"] == "enabled"%}

--- a/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -11,13 +11,13 @@
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
     {%- if cookiecutter["Powertools for AWS Lambda (.NET) Tracing"] == "enabled"%}
-    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.3.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.3.2" />
     {%- endif %}
     {%- if cookiecutter["Powertools for AWS Lambda (.NET) Metrics"] == "enabled"%}
-    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.4.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.4.2" />
     {%- endif %}
     {%- if cookiecutter["Powertools for AWS Lambda (.NET) Logging"] == "enabled"%}
-    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.3.0" />
+    <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.3.2" />
     {%- endif %}
   </ItemGroup>
 </Project>

--- a/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/dotnet6/hello-pt/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
     {%- if cookiecutter["Powertools for AWS Lambda (.NET) Tracing"] == "enabled"%}
-    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.11.0" />
+    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.12.0" />
     <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.3.0" />
     {%- endif %}
     {%- if cookiecutter["Powertools for AWS Lambda (.NET) Metrics"] == "enabled"%}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update Powertools dotnet6 template versions with new versions from release 1.7.0
Also took the opportunity to update Amazon.Lambda.Serialization.SystemTextJson and Amazon.Lambda.APIGatewayEvents

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
