### PR TITLE
chore: bump cookiecutter from 2.1.1 to 2.3.0

### DIFF
--- a/al2/dotnet7-aot/hello/cookiecutter.json
+++ b/al2/dotnet7-aot/hello/cookiecutter.json
@@ -3,7 +3,7 @@
     "runtime": "provided.al2",
     "architectures": {
         "value": [
-            "x86_64"
+            "x86_64", "arm64"
         ]
     },
     "_copy_without_render": [

--- a/al2/go/event-bridge-schema/cookiecutter.json
+++ b/al2/go/event-bridge-schema/cookiecutter.json
@@ -3,7 +3,7 @@
     "runtime": "provided.al2",
     "architectures": {
         "value": [
-            [ "x86_64", "arm64" ]
+            "x86_64", "arm64"
         ]
     },
     "function_name": "HelloWorld",

--- a/al2/go/event-bridge-schema/requirements-dev.txt
+++ b/al2/go/event-bridge-schema/requirements-dev.txt
@@ -1,4 +1,4 @@
-cookiecutter==2.1.1
+cookiecutter==2.3.0
 flake8==3.5.0
 pytest==3.3.2
 pytest-cookies==0.3.0

--- a/al2/go/event-bridge/cookiecutter.json
+++ b/al2/go/event-bridge/cookiecutter.json
@@ -3,7 +3,7 @@
     "runtime": "provided.al2",
     "architectures": {
         "value": [
-            [ "x86_64", "arm64" ]
+            "x86_64", "arm64"
         ]
     },
     "_copy_without_render": [

--- a/al2/go/event-bridge/requirements-dev.txt
+++ b/al2/go/event-bridge/requirements-dev.txt
@@ -1,4 +1,4 @@
-cookiecutter==2.1.1
+cookiecutter==2.3.0
 flake8==3.5.0
 pytest==3.3.2
 pytest-cookies==0.3.0

--- a/al2/go/hello-img/requirements-dev.txt
+++ b/al2/go/hello-img/requirements-dev.txt
@@ -1,4 +1,4 @@
-cookiecutter==2.1.1
+cookiecutter==2.3.0
 flake8==3.5.0
 pytest==3.3.2
 pytest-cookies==0.3.0

--- a/al2/go/hello/cookiecutter.json
+++ b/al2/go/hello/cookiecutter.json
@@ -3,7 +3,7 @@
     "runtime": "provided.al2",
     "architectures": {
         "value": [
-            [ "x86_64", "arm64" ]
+            "x86_64", "arm64"
         ]
     },
     "_copy_without_render": [

--- a/al2/go/hello/requirements-dev.txt
+++ b/al2/go/hello/requirements-dev.txt
@@ -1,4 +1,4 @@
-cookiecutter==2.1.1
+cookiecutter==2.3.0
 flake8==3.5.0
 pytest==3.3.2
 pytest-cookies==0.3.0

--- a/al2/go/step-func/cookiecutter.json
+++ b/al2/go/step-func/cookiecutter.json
@@ -3,7 +3,7 @@
     "runtime": "provided.al2",
     "architectures": {
         "value": [
-            [ "x86_64", "arm64" ]
+            "x86_64", "arm64"
         ]
     },
     "_copy_without_render": [

--- a/al2/go/step-func/requirements-dev.txt
+++ b/al2/go/step-func/requirements-dev.txt
@@ -1,4 +1,4 @@
-cookiecutter==2.1.1
+cookiecutter==2.3.0
 flake8==3.5.0
 pytest==3.3.2
 pytest-cookies==0.3.0

--- a/al2/graalvm/11/gradle/cookiecutter.json
+++ b/al2/graalvm/11/gradle/cookiecutter.json
@@ -2,7 +2,7 @@
     "project_name": "Name of the project",
     "architectures": {
         "value": [
-            ["x86_64"]
+            "x86_64", "arm64"
         ]
     },
     "_copy_without_render": [

--- a/al2/graalvm/11/maven/cookiecutter.json
+++ b/al2/graalvm/11/maven/cookiecutter.json
@@ -2,7 +2,7 @@
     "project_name": "Name of the project",
     "architectures": {
         "value": [
-            ["x86_64"]
+            "x86_64", "arm64"
         ]
     },
     "_copy_without_render": [

--- a/al2/graalvm/17/gradle/cookiecutter.json
+++ b/al2/graalvm/17/gradle/cookiecutter.json
@@ -2,7 +2,7 @@
     "project_name": "Name of the project",
     "architectures": {
         "value": [
-            ["x86_64"]
+            "x86_64", "arm64"
         ]
     },
     "_copy_without_render": [

--- a/al2/graalvm/17/maven/cookiecutter.json
+++ b/al2/graalvm/17/maven/cookiecutter.json
@@ -2,7 +2,7 @@
     "project_name": "Name of the project",
     "architectures": {
         "value": [
-            ["x86_64"]
+            "x86_64", "arm64"
         ]
     },
     "_copy_without_render": [

--- a/al2/rust/hello/cookiecutter.json
+++ b/al2/rust/hello/cookiecutter.json
@@ -2,7 +2,7 @@
   "project_name": "My Project",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
   "architectures": {
-    "value": []
+    "value": ["x86_64"]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/dotnet6/hello-pt/cookiecutter.json
+++ b/dotnet6/hello-pt/cookiecutter.json
@@ -2,7 +2,7 @@
     "project_name": "SamAppPowertools for AWS Lambda",
     "runtime": "dotnet6",
     "architectures": {
-        "value": []
+        "value": [ "x86_64", "arm64" ]
     },
     "Powertools for AWS Lambda (.NET) Tracing": ["enabled","disabled"],
     "Powertools for AWS Lambda (.NET) Metrics": ["enabled","disabled"],

--- a/go1.x/event-bridge-schema/cookiecutter.json
+++ b/go1.x/event-bridge-schema/cookiecutter.json
@@ -2,7 +2,7 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "go1.x",
     "architectures": {
-        "value": []
+        "value": [ "x86_64" ]
     },
     "function_name": "HelloWorld",
     "AWS_Schema_registry": "aws.events",

--- a/go1.x/event-bridge-schema/requirements-dev.txt
+++ b/go1.x/event-bridge-schema/requirements-dev.txt
@@ -1,4 +1,4 @@
-cookiecutter==2.1.1
+cookiecutter==2.3.0
 flake8==3.5.0
 pytest==3.3.2
 pytest-cookies==0.3.0

--- a/go1.x/event-bridge/cookiecutter.json
+++ b/go1.x/event-bridge/cookiecutter.json
@@ -2,7 +2,7 @@
     "project_name": "Your EventBridge Starter App",
     "runtime": "go1.x",
     "architectures": {
-        "value": []
+        "value": [ "x86_64" ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/go1.x/event-bridge/requirements-dev.txt
+++ b/go1.x/event-bridge/requirements-dev.txt
@@ -1,4 +1,4 @@
-cookiecutter==2.1.1
+cookiecutter==2.3.0
 flake8==3.5.0
 pytest==3.3.2
 pytest-cookies==0.3.0

--- a/go1.x/hello-img/cookiecutter.json
+++ b/go1.x/hello-img/cookiecutter.json
@@ -2,7 +2,7 @@
     "project_name": "Name of the project",
     "runtime": "go1.x",
     "architectures": {
-        "value": []
+        "value": [ "x86_64" ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/go1.x/hello-img/requirements-dev.txt
+++ b/go1.x/hello-img/requirements-dev.txt
@@ -1,4 +1,4 @@
-cookiecutter==2.1.1
+cookiecutter==2.3.0
 flake8==3.5.0
 pytest==3.3.2
 pytest-cookies==0.3.0

--- a/go1.x/hello/cookiecutter.json
+++ b/go1.x/hello/cookiecutter.json
@@ -2,7 +2,7 @@
     "project_name": "Name of the project",
     "runtime": "go1.x",
     "architectures": {
-        "value": []
+        "value": [ "x86_64" ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/go1.x/hello/requirements-dev.txt
+++ b/go1.x/hello/requirements-dev.txt
@@ -1,4 +1,4 @@
-cookiecutter==2.1.1
+cookiecutter==2.3.0
 flake8==3.5.0
 pytest==3.3.2
 pytest-cookies==0.3.0

--- a/go1.x/step-func/cookiecutter.json
+++ b/go1.x/step-func/cookiecutter.json
@@ -2,7 +2,7 @@
     "project_name": "Name of the project",
     "runtime": "go1.x",
     "architectures": {
-        "value": []
+        "value": [ "x86_64" ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/go1.x/step-func/requirements-dev.txt
+++ b/go1.x/step-func/requirements-dev.txt
@@ -1,4 +1,4 @@
-cookiecutter==2.1.1
+cookiecutter==2.3.0
 flake8==3.5.0
 pytest==3.3.2
 pytest-cookies==0.3.0

--- a/java11/event-bridge-gradle/cookiecutter.json
+++ b/java11/event-bridge-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "java11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java11/event-bridge-maven/cookiecutter.json
+++ b/java11/event-bridge-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "java11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java11/event-bridge-schema-gradle/cookiecutter.json
+++ b/java11/event-bridge-schema-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "java11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "function_name": "HelloWorldFunction",
     "AWS_Schema_registry": "aws.events",

--- a/java11/event-bridge-schema-maven/cookiecutter.json
+++ b/java11/event-bridge-schema-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "java11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "function_name": "HelloWorldFunction",
     "AWS_Schema_registry": "aws.events",

--- a/java11/hello-gradle/cookiecutter.json
+++ b/java11/hello-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java11/hello-img-gradle/cookiecutter.json
+++ b/java11/hello-img-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java11/hello-img-maven/cookiecutter.json
+++ b/java11/hello-img-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java11/hello-maven/cookiecutter.json
+++ b/java11/hello-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java11/step-func-gradle/cookiecutter.json
+++ b/java11/step-func-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java11/step-func-maven/cookiecutter.json
+++ b/java11/step-func-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java17/event-bridge-gradle/cookiecutter.json
+++ b/java17/event-bridge-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "java17",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java17/event-bridge-maven/cookiecutter.json
+++ b/java17/event-bridge-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "java17",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java17/event-bridge-schema-gradle/cookiecutter.json
+++ b/java17/event-bridge-schema-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "java17",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "function_name": "HelloWorldFunction",
     "AWS_Schema_registry": "aws.events",

--- a/java17/event-bridge-schema-maven/cookiecutter.json
+++ b/java17/event-bridge-schema-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "java17",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "function_name": "HelloWorldFunction",
     "AWS_Schema_registry": "aws.events",

--- a/java17/hello-gradle/cookiecutter.json
+++ b/java17/hello-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java17",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java17/hello-img-gradle/cookiecutter.json
+++ b/java17/hello-img-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java17",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java17/hello-img-maven/cookiecutter.json
+++ b/java17/hello-img-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java17",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java17/hello-maven/cookiecutter.json
+++ b/java17/hello-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java17",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java17/step-func-gradle/cookiecutter.json
+++ b/java17/step-func-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java17",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java17/step-func-maven/cookiecutter.json
+++ b/java17/step-func-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java17",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java8.al2/event-bridge-gradle/cookiecutter.json
+++ b/java8.al2/event-bridge-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "java8.al2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java8.al2/event-bridge-maven/cookiecutter.json
+++ b/java8.al2/event-bridge-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "java8.al2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java8.al2/event-bridge-schema-gradle/cookiecutter.json
+++ b/java8.al2/event-bridge-schema-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "java8.al2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "function_name": "HelloWorldFunction",
     "AWS_Schema_registry": "aws.events",

--- a/java8.al2/event-bridge-schema-maven/cookiecutter.json
+++ b/java8.al2/event-bridge-schema-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "java8.al2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "function_name": "HelloWorldFunction",
     "AWS_Schema_registry": "aws.events",

--- a/java8.al2/hello-gradle/cookiecutter.json
+++ b/java8.al2/hello-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java8.al2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java8.al2/hello-img-gradle/cookiecutter.json
+++ b/java8.al2/hello-img-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java8.al2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java8.al2/hello-img-maven/cookiecutter.json
+++ b/java8.al2/hello-img-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java8.al2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java8.al2/hello-maven/cookiecutter.json
+++ b/java8.al2/hello-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java8.al2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java8.al2/step-func-gradle/cookiecutter.json
+++ b/java8.al2/step-func-gradle/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java8.al2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/java8.al2/step-func-maven/cookiecutter.json
+++ b/java8.al2/step-func-maven/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "java8.al2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs14.x/cw-event/cookiecutter.json
+++ b/nodejs14.x/cw-event/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs14.x/hello-img/cookiecutter.json
+++ b/nodejs14.x/hello-img/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs14.x/hello-ts-pt/cookiecutter.json
+++ b/nodejs14.x/hello-ts-pt/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "Powertools for AWS Lambda (TypeScript) Tracing": ["enabled","disabled"],
     "Powertools for AWS Lambda (TypeScript) Metrics": ["enabled","disabled"],

--- a/nodejs14.x/hello-ts/cookiecutter.json
+++ b/nodejs14.x/hello-ts/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs14.x/hello/cookiecutter.json
+++ b/nodejs14.x/hello/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs14.x/s3/cookiecutter.json
+++ b/nodejs14.x/s3/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs14.x/scratch/cookiecutter.json
+++ b/nodejs14.x/scratch/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs14.x/sns/cookiecutter.json
+++ b/nodejs14.x/sns/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs14.x/sqs/cookiecutter.json
+++ b/nodejs14.x/sqs/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs14.x/step-func-conn/cookiecutter.json
+++ b/nodejs14.x/step-func-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs14.x/step-func/cookiecutter.json
+++ b/nodejs14.x/step-func/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs14.x/web-conn/cookiecutter.json
+++ b/nodejs14.x/web-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs14.x/web/cookiecutter.json
+++ b/nodejs14.x/web/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs14.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/cw-event/cookiecutter.json
+++ b/nodejs16.x/cw-event/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/hello-img/cookiecutter.json
+++ b/nodejs16.x/hello-img/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/hello-ts-pt/cookiecutter.json
+++ b/nodejs16.x/hello-ts-pt/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "Powertools for AWS Lambda (TypeScript) Tracing": ["enabled","disabled"],
     "Powertools for AWS Lambda (TypeScript) Metrics": ["enabled","disabled"],

--- a/nodejs16.x/hello-ts/cookiecutter.json
+++ b/nodejs16.x/hello-ts/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/hello/cookiecutter.json
+++ b/nodejs16.x/hello/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/response-streaming/cookiecutter.json
+++ b/nodejs16.x/response-streaming/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/s3/cookiecutter.json
+++ b/nodejs16.x/s3/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/scratch/cookiecutter.json
+++ b/nodejs16.x/scratch/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/sns/cookiecutter.json
+++ b/nodejs16.x/sns/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/sqs/cookiecutter.json
+++ b/nodejs16.x/sqs/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/step-func-conn/cookiecutter.json
+++ b/nodejs16.x/step-func-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/step-func/cookiecutter.json
+++ b/nodejs16.x/step-func/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/web-conn/cookiecutter.json
+++ b/nodejs16.x/web-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs16.x/web/cookiecutter.json
+++ b/nodejs16.x/web/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs16.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs18.x/cw-event/cookiecutter.json
+++ b/nodejs18.x/cw-event/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs18.x/full-stack/cookiecutter.json
+++ b/nodejs18.x/full-stack/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore",

--- a/nodejs18.x/hello-gql/cookiecutter.json
+++ b/nodejs18.x/hello-gql/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs18.x/hello-img/cookiecutter.json
+++ b/nodejs18.x/hello-img/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs18.x/hello-ts-pt/cookiecutter.json
+++ b/nodejs18.x/hello-ts-pt/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "Powertools for AWS Lambda (TypeScript) Tracing": ["enabled","disabled"],
     "Powertools for AWS Lambda (TypeScript) Metrics": ["enabled","disabled"],

--- a/nodejs18.x/hello-ts/cookiecutter.json
+++ b/nodejs18.x/hello-ts/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs18.x/hello/cookiecutter.json
+++ b/nodejs18.x/hello/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs18.x/response-streaming/cookiecutter.json
+++ b/nodejs18.x/response-streaming/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs18.x/s3/cookiecutter.json
+++ b/nodejs18.x/s3/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs18.x/scratch/cookiecutter.json
+++ b/nodejs18.x/scratch/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs18.x/sns/cookiecutter.json
+++ b/nodejs18.x/sns/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs18.x/sqs/cookiecutter.json
+++ b/nodejs18.x/sqs/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs18.x/step-func/cookiecutter.json
+++ b/nodejs18.x/step-func/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/nodejs18.x/web/cookiecutter.json
+++ b/nodejs18.x/web/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "nodejs18.x",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.10/apigw-pytorch/cookiecutter.json
+++ b/python3.10/apigw-pytorch/cookiecutter.json
@@ -5,8 +5,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.10/apigw-scikit/cookiecutter.json
+++ b/python3.10/apigw-scikit/cookiecutter.json
@@ -4,8 +4,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.10/apigw-tensorflow/cookiecutter.json
+++ b/python3.10/apigw-tensorflow/cookiecutter.json
@@ -4,8 +4,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.10/apigw-xgboost/cookiecutter.json
+++ b/python3.10/apigw-xgboost/cookiecutter.json
@@ -4,8 +4,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.10/efs/cookiecutter.json
+++ b/python3.10/efs/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.10",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.10/event-bridge-schema/cookiecutter.json
+++ b/python3.10/event-bridge-schema/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "python3.10",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "function_name": "hello_world_function",
     "AWS_Schema_registry": "aws.events",

--- a/python3.10/event-bridge/cookiecutter.json
+++ b/python3.10/event-bridge/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.10",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.10/hello-img/cookiecutter.json
+++ b/python3.10/hello-img/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.10",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.10/hello-pt/cookiecutter.json
+++ b/python3.10/hello-pt/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "sam-app-powertools",
     "runtime": "python3.10",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "Powertools for AWS Lambda (Python) Logging": ["enabled","disabled"],
     "Powertools for AWS Lambda (Python) Metrics": ["enabled","disabled"],

--- a/python3.10/hello/cookiecutter.json
+++ b/python3.10/hello/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.10",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.10/step-func-conn/cookiecutter.json
+++ b/python3.10/step-func-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.10",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.10/step-func/cookiecutter.json
+++ b/python3.10/step-func/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.10",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.10/web-conn/cookiecutter.json
+++ b/python3.10/web-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.10",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.11/apigw-pytorch/cookiecutter.json
+++ b/python3.11/apigw-pytorch/cookiecutter.json
@@ -5,8 +5,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.11/apigw-scikit/cookiecutter.json
+++ b/python3.11/apigw-scikit/cookiecutter.json
@@ -4,8 +4,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.11/apigw-tensorflow/cookiecutter.json
+++ b/python3.11/apigw-tensorflow/cookiecutter.json
@@ -4,8 +4,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.11/apigw-xgboost/cookiecutter.json
+++ b/python3.11/apigw-xgboost/cookiecutter.json
@@ -4,8 +4,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.11/efs/cookiecutter.json
+++ b/python3.11/efs/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.11/event-bridge-schema/cookiecutter.json
+++ b/python3.11/event-bridge-schema/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "python3.11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "function_name": "hello_world_function",
     "AWS_Schema_registry": "aws.events",

--- a/python3.11/event-bridge/cookiecutter.json
+++ b/python3.11/event-bridge/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.11/hello-img/cookiecutter.json
+++ b/python3.11/hello-img/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.11/hello-pt/cookiecutter.json
+++ b/python3.11/hello-pt/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "sam-app-powertools",
     "runtime": "python3.11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "Powertools Logging": ["enabled","disabled"],
     "Powertools Metrics": ["enabled","disabled"],

--- a/python3.11/hello/cookiecutter.json
+++ b/python3.11/hello/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.11/step-func-conn/cookiecutter.json
+++ b/python3.11/step-func-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.11/step-func/cookiecutter.json
+++ b/python3.11/step-func/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.11/web-conn/cookiecutter.json
+++ b/python3.11/web-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.11",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.7/hello-pt/cookiecutter.json
+++ b/python3.7/hello-pt/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "sam-app-powertools",
     "runtime": "python3.7",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "Powertools for AWS Lambda (Python) Logging": ["enabled","disabled"],
     "Powertools for AWS Lambda (Python) Metrics": ["enabled","disabled"],

--- a/python3.7/step-func-conn/cookiecutter.json
+++ b/python3.7/step-func-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.7",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.7/web-conn/cookiecutter.json
+++ b/python3.7/web-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.7",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.8/apigw-pytorch/cookiecutter.json
+++ b/python3.8/apigw-pytorch/cookiecutter.json
@@ -5,8 +5,8 @@
   "torchvision_version": "0.14.1",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.8/apigw-scikit/cookiecutter.json
+++ b/python3.8/apigw-scikit/cookiecutter.json
@@ -3,8 +3,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.8/apigw-tensorflow/cookiecutter.json
+++ b/python3.8/apigw-tensorflow/cookiecutter.json
@@ -3,8 +3,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.8/apigw-xgboost/cookiecutter.json
+++ b/python3.8/apigw-xgboost/cookiecutter.json
@@ -3,8 +3,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.8/efs/cookiecutter.json
+++ b/python3.8/efs/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.8",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.8/event-bridge-schema/cookiecutter.json
+++ b/python3.8/event-bridge-schema/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "python3.8",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "function_name": "hello_world_function",
     "AWS_Schema_registry": "aws.events",

--- a/python3.8/event-bridge/cookiecutter.json
+++ b/python3.8/event-bridge/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.8",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.8/hello-img/cookiecutter.json
+++ b/python3.8/hello-img/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.8",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.8/hello-pt/cookiecutter.json
+++ b/python3.8/hello-pt/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "sam-app-powertools",
     "runtime": "python3.8",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "Powertools for AWS Lambda (Python) Logging": ["enabled","disabled"],
     "Powertools for AWS Lambda (Python) Metrics": ["enabled","disabled"],

--- a/python3.8/hello/cookiecutter.json
+++ b/python3.8/hello/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.8",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.8/step-func-conn/cookiecutter.json
+++ b/python3.8/step-func-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.8",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.8/step-func/cookiecutter.json
+++ b/python3.8/step-func/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.8",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.8/web-conn/cookiecutter.json
+++ b/python3.8/web-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.8",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.9/apigw-pytorch/cookiecutter.json
+++ b/python3.9/apigw-pytorch/cookiecutter.json
@@ -5,8 +5,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.9/apigw-scikit/cookiecutter.json
+++ b/python3.9/apigw-scikit/cookiecutter.json
@@ -4,8 +4,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.9/apigw-tensorflow/cookiecutter.json
+++ b/python3.9/apigw-tensorflow/cookiecutter.json
@@ -4,8 +4,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.9/apigw-xgboost/cookiecutter.json
+++ b/python3.9/apigw-xgboost/cookiecutter.json
@@ -4,8 +4,8 @@
   "api_path": "/classify_digit",
   "architectures": {
     "value": [
-      "x86_64"
-    ]
+      "x86_64", "arm64"
+  ]
   },
   "_copy_without_render": [
     ".gitignore"

--- a/python3.9/efs/cookiecutter.json
+++ b/python3.9/efs/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.9",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.9/event-bridge-schema/cookiecutter.json
+++ b/python3.9/event-bridge-schema/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Your EventBridge Starter app",
     "runtime": "python3.9",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "function_name": "hello_world_function",
     "AWS_Schema_registry": "aws.events",

--- a/python3.9/event-bridge/cookiecutter.json
+++ b/python3.9/event-bridge/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.9",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.9/hello-img/cookiecutter.json
+++ b/python3.9/hello-img/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.9",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.9/hello-pt/cookiecutter.json
+++ b/python3.9/hello-pt/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "sam-app-powertools",
     "runtime": "python3.9",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "Powertools for AWS Lambda (Python) Logging": ["enabled","disabled"],
     "Powertools for AWS Lambda (Python) Metrics": ["enabled","disabled"],

--- a/python3.9/hello/cookiecutter.json
+++ b/python3.9/hello/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.9",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.9/step-func-conn/cookiecutter.json
+++ b/python3.9/step-func-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.9",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.9/step-func/cookiecutter.json
+++ b/python3.9/step-func/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.9",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/python3.9/web-conn/cookiecutter.json
+++ b/python3.9/web-conn/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "python3.9",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/ruby2.7/hello-img/cookiecutter.json
+++ b/ruby2.7/hello-img/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "ruby2.7",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/ruby2.7/hello/cookiecutter.json
+++ b/ruby2.7/hello/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "ruby2.7",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/ruby2.7/step-func/cookiecutter.json
+++ b/ruby2.7/step-func/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "ruby2.7",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/ruby3.2/hello-img/cookiecutter.json
+++ b/ruby3.2/hello-img/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "ruby3.2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/ruby3.2/hello/cookiecutter.json
+++ b/ruby3.2/hello/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "ruby3.2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"

--- a/ruby3.2/step-func/cookiecutter.json
+++ b/ruby3.2/step-func/cookiecutter.json
@@ -2,7 +2,9 @@
     "project_name": "Name of the project",
     "runtime": "ruby3.2",
     "architectures": {
-        "value": []
+        "value": [
+            "x86_64", "arm64"
+        ]
     },
     "_copy_without_render": [
         ".gitignore"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

PR related to sam cli [PR](https://github.com/aws/aws-sam-cli/pull/5834)

This PR updates the templates to follow the code changes in the cookiecutter library. The current version of cookiecutter would directly assign `architectures` list without looking recursively. The new version recursively looks through the keys and overrides the values. The new changes in [cookiecutter](https://github.com/cookiecutter/cookiecutter/blob/main/cookiecutter/generate.py#L49-L87) also checks if the override value is a valid choice present in the default choices list. This PR updates the default choices of architectures based on runtime. The following [docs page](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) was followed for architectures.

All the runtimes have the default architectures as `["x86_64", "arm64"]` except the following runtimes:

```
python3.7: x86_64
Go1.x:  x86_64
rust: x86_64
java8: no arch specified
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
