### PR TITLE
chore: Bump pillow to 10.1.0 for py3.8 pytorch project

### DIFF
--- a/python3.8/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.8/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 torch=={{cookiecutter.pytorch_version}}+cpu
 torchvision=={{cookiecutter.torchvision_version}}+cpu
-pillow==9.3.0
+pillow==10.1.0


### PR DESCRIPTION
*Issue #, if available:*
None.

*Description of changes:*
Bumps the pinned version of `pytorch` for the Python 3.8 runtime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
