### PR TITLE
Replace failing grep with builtin query

### DIFF
--- a/nodejs18.x/full-stack/{{cookiecutter.project_name}}/deploy_frontend.sh
+++ b/nodejs18.x/full-stack/{{cookiecutter.project_name}}/deploy_frontend.sh
@@ -37,8 +37,7 @@ npm run build && cd dist/
 aws s3 sync . s3://$s3_bucket_name/
 
 # Create cloudfront invalidation and capture id for next step
-invalidation_output=$(aws cloudfront create-invalidation --distribution-id $cloudfront_distribution_id --paths "/*")
-invalidation_id=$(echo "$invalidation_output" | grep -oP '(?<="Id": ")[^"]+')
+invalidation_id=$(aws cloudfront create-invalidation --distribution-id $cloudfront_distribution_id --paths "/*" --query "Invalidation.Id" --output text)
 
 # Wait for cloudfront invalidation to complete
 aws cloudfront wait invalidation-completed --distribution-id $cloudfront_distribution_id --id $invalidation_id


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-sam-cli/issues/5940 Script was failing for MacOS's default grep command


*Description of changes:*

Replace `grep` with aws cli's builtin `query` as `-P` regex in grep is not supported by MacOS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
