### PR TITLE
chore: Bump SAM CLI install version for Actions

### DIFF
--- a/.github/workflows/build_test_invoke.yml
+++ b/.github/workflows/build_test_invoke.yml
@@ -8,7 +8,7 @@ on:
     branches: [master, "feat*"]
 
 env:
-  PYTHON_VERSION_INSTALL: '3.11'
+  PYTHON_VERSION_INSTALL: '3.8'
   SAM_CLI_DEV: 1
   PIP_CARGO_LAMBDA_VERSION: '0.17.1'
 
@@ -101,7 +101,7 @@ jobs:
             type: 'Invoke'
             file: 'tests/integration/build_invoke/python/test_python_3_11.py'
     env:
-      PYTHON_VERSION_INSTALL: 3.11
+      PYTHON_VERSION_INSTALL: 3.8
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -109,7 +109,7 @@ jobs:
       - uses: ./.github/actions/aws-sam-cli-develop
         name: Install develop version of AWS SAM CLI
         env:
-          PYTHON_VERSION_INSTALL: 3.11
+          PYTHON_VERSION_INSTALL: 3.8
       - uses: actions/setup-python@v4
         name: Setup Python ${{ matrix.version }}
         with:

--- a/.github/workflows/build_test_invoke.yml
+++ b/.github/workflows/build_test_invoke.yml
@@ -8,7 +8,7 @@ on:
     branches: [master, "feat*"]
 
 env:
-  PYTHON_VERSION_INSTALL: '3.7'
+  PYTHON_VERSION_INSTALL: '3.11'
   SAM_CLI_DEV: 1
   PIP_CARGO_LAMBDA_VERSION: '0.17.1'
 
@@ -101,7 +101,7 @@ jobs:
             type: 'Invoke'
             file: 'tests/integration/build_invoke/python/test_python_3_11.py'
     env:
-      PYTHON_VERSION_INSTALL: ${{ matrix.version }}
+      PYTHON_VERSION_INSTALL: 3.11
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -109,7 +109,7 @@ jobs:
       - uses: ./.github/actions/aws-sam-cli-develop
         name: Install develop version of AWS SAM CLI
         env:
-          PYTHON_VERSION_INSTALL: ${{ matrix.version }}
+          PYTHON_VERSION_INSTALL: 3.11
       - uses: actions/setup-python@v4
         name: Setup Python ${{ matrix.version }}
         with:

--- a/.github/workflows/build_test_invoke.yml
+++ b/.github/workflows/build_test_invoke.yml
@@ -100,16 +100,12 @@ jobs:
           - version: '3.11'
             type: 'Invoke'
             file: 'tests/integration/build_invoke/python/test_python_3_11.py'
-    env:
-      PYTHON_VERSION_INSTALL: 3.8
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         name: Checkout PR
       - uses: ./.github/actions/aws-sam-cli-develop
         name: Install develop version of AWS SAM CLI
-        env:
-          PYTHON_VERSION_INSTALL: 3.8
       - uses: actions/setup-python@v4
         name: Setup Python ${{ matrix.version }}
         with:

--- a/.github/workflows/build_test_invoke.yml
+++ b/.github/workflows/build_test_invoke.yml
@@ -8,7 +8,7 @@ on:
     branches: [master, "feat*"]
 
 env:
-  PYTHON_VERSION_INSTALL: '3.8'
+  PYTHON_VERSION_INSTALL: '3.11'
   SAM_CLI_DEV: 1
   PIP_CARGO_LAMBDA_VERSION: '0.17.1'
 


### PR DESCRIPTION
*Issue #, if available:*
None.

*Description of changes:*
Bumps the minimum version of Python that is used to install SAM CLI from source in the actions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
