### PR TITLE
Bump timeout for this test to 10 seconds to investigate flaky test

### DIFF
--- a/go1.x/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/go1.x/hello/{{cookiecutter.project_name}}/template.yaml
@@ -8,7 +8,7 @@ Description: >
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 5
+    Timeout: 10
     MemorySize: 128
 
 Resources:


### PR DESCRIPTION
This sam cli test is timing out on windows occasionally: `tests/end_to_end/test_runtimes_e2e.py::TestHelloWorldZipPackagePermissionsEndToEnd_0_go1_x`

*Description of changes:*
Bumping the timeout as an investigation method to see if this changes the result


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
