### PR TITLE
Temporarily bump timeout for flaky test

### DIFF
--- a/go1.x/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/go1.x/hello/{{cookiecutter.project_name}}/template.yaml
@@ -8,7 +8,7 @@ Description: >
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 5
+    Timeout: 10
     MemorySize: 128
 
 Resources:


### PR DESCRIPTION
`tests/end_to_end/test_runtimes_e2e.py::TestHelloWorldZipPackagePermissionsEndToEnd_0_go1_x::test_hello_world_workflow` test is flaky only on windows canaries but is not reproducible on windows VMs, and we cannot determine the root cause. 

Temporarily bumping the timeout from 5s to 10s for a week before go1.x is deprecated to see if that changes anything.
