### PR TITLE
Update Pillow version due to CVE with 10.1

### DIFF
--- a/python3.8/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.8/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 torch=={{cookiecutter.pytorch_version}}+cpu
 torchvision=={{cookiecutter.torchvision_version}}+cpu
-pillow==10.1.0
+pillow==10.2.0


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli-app-templates/security/dependabot/235

*Description of changes:*
Pillow has a CVE with version 10.1.0. I checked in our repo and our pillow dependencies are all not fixed or 10.2.0 which is patched except for one runtime, Python3.8. I think we can bump this version because I see in the [Pillow docs](https://pillow.readthedocs.io/en/stable/installation.html) that 10.2.0 is supported or Python3.8


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
