### PR TITLE
Update Node makefile create targets to use mock asl definition for testing

### DIFF
--- a/nodejs16.x/step-func-conn/{{cookiecutter.project_name}}/makefile
+++ b/nodejs16.x/step-func-conn/{{cookiecutter.project_name}}/makefile
@@ -10,7 +10,7 @@ create:
 	sed -E -e 's/\$$\{.+\}/arn:aws:lambda:us-east-1:123456789012:function:mock/' statemachine/stock_trader.asl.json > statemachine/test/mocked.test.asl.json
 	aws stepfunctions create-state-machine \
 		--endpoint-url http://localhost:8083 \
-		--definition file://statemachine/stock_trader.asl.json \
+		--definition file://statemachine/test/mocked.test.asl.json \
 		--name "StockTradingLocalTesting" \
 		--role-arn "arn:aws:iam::123456789012:role/DummyRole" \
 		--no-cli-pager

--- a/nodejs16.x/step-func/{{cookiecutter.project_name}}/makefile
+++ b/nodejs16.x/step-func/{{cookiecutter.project_name}}/makefile
@@ -10,7 +10,7 @@ create:
 	sed -E -e 's/\$$\{.+\}/arn:aws:lambda:us-east-1:123456789012:function:mock/' statemachine/stock_trader.asl.json > statemachine/test/mocked.test.asl.json
 	aws stepfunctions create-state-machine \
 		--endpoint-url http://localhost:8083 \
-		--definition file://statemachine/stock_trader.asl.json \
+		--definition file://statemachine/test/mocked.test.asl.json \
 		--name "StockTradingLocalTesting" \
 		--role-arn "arn:aws:iam::123456789012:role/DummyRole" \
 		--no-cli-pager

--- a/nodejs18.x/step-func/{{cookiecutter.project_name}}/makefile
+++ b/nodejs18.x/step-func/{{cookiecutter.project_name}}/makefile
@@ -10,7 +10,7 @@ create:
 	sed -E -e 's/\$$\{.+\}/arn:aws:lambda:us-east-1:123456789012:function:mock/' statemachine/stock_trader.asl.json > statemachine/test/mocked.test.asl.json
 	aws stepfunctions create-state-machine \
 		--endpoint-url http://localhost:8083 \
-		--definition file://statemachine/stock_trader.asl.json \
+		--definition file://statemachine/test/mocked.test.asl.json \
 		--name "StockTradingLocalTesting" \
 		--role-arn "arn:aws:iam::123456789012:role/DummyRole" \
 		--no-cli-pager

--- a/nodejs20.x/step-func/{{cookiecutter.project_name}}/makefile
+++ b/nodejs20.x/step-func/{{cookiecutter.project_name}}/makefile
@@ -10,7 +10,7 @@ create:
 	sed -E -e 's/\$$\{.+\}/arn:aws:lambda:us-east-1:123456789012:function:mock/' statemachine/stock_trader.asl.json > statemachine/test/mocked.test.asl.json
 	aws stepfunctions create-state-machine \
 		--endpoint-url http://localhost:8083 \
-		--definition file://statemachine/stock_trader.asl.json \
+		--definition file://statemachine/test/mocked.test.asl.json \
 		--name "StockTradingLocalTesting" \
 		--role-arn "arn:aws:iam::123456789012:role/DummyRole" \
 		--no-cli-pager


### PR DESCRIPTION
*Issue #, if available:*
Related to #346

*Description of changes:*
Changes made in #346 created the mocked.test.asl.json file appropriately, but did not use it for the `aws stepfunctions create-state-machine --definition` argument. This PR updates the node v16/18/20 step-func makefiles to do so. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
