### PR TITLE
fix: Typo in nodejs20 hello-ts-pt package.json

### DIFF
--- a/nodejs20.x/hello-ts-pt/{{cookiecutter.project_name}}/hello-world/package.json
+++ b/nodejs20.x/hello-ts-pt/{{cookiecutter.project_name}}/hello-world/package.json
@@ -1,4 +1,5 @@
-2{0 3"name": "hello_world",
+{
+  "name": "hello_world",
   "version": "1.0.0",
   "description": "hello world sample for NodeJS",
   "main": "app.js",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Fixing what appears to be a typo in the `package.json` of the NodeJS 20 Hello Lambda TypeScript with PowerTools template.  I do not see a test case for this one, but I validated that the changes make it so the `package.json` parses and `npm install` works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
