### PR TITLE
fix: Use the SAM build images to build image based Ruby functions

### DIFF
--- a/ruby/hello-img/{{cookiecutter.project_name}}/hello_world/Dockerfile
+++ b/ruby/hello-img/{{cookiecutter.project_name}}/hello_world/Dockerfile
@@ -3,7 +3,12 @@ FROM public.ecr.aws/lambda/ruby:{{ cookiecutter.options[cookiecutter.runtime].ve
 COPY app.rb Gemfile ./
 
 ENV GEM_HOME=${LAMBDA_TASK_ROOT}
+
+# Install dev tools so that `bigdecimal` (a dep of httparty) can be installed
+RUN yum install gcc make -y
 RUN bundle install
+# Remove the dev tools
+RUN yum uninstall gcc make -y
 
 # Command can be overwritten by providing a different command in the template directly.
 CMD ["app.lambda_handler"]

--- a/ruby/hello-img/{{cookiecutter.project_name}}/hello_world/Dockerfile
+++ b/ruby/hello-img/{{cookiecutter.project_name}}/hello_world/Dockerfile
@@ -19,5 +19,5 @@ ENV GEM_HOME=${LAMBDA_TASK_ROOT}
 
 COPY --from=build-image /var/task/ ./
 
-# # Command can be overwritten by providing a different command in the template directly.
+# Command can be overwritten by providing a different command in the template directly.
 CMD ["app.lambda_handler"]

--- a/ruby/hello-img/{{cookiecutter.project_name}}/hello_world/Dockerfile
+++ b/ruby/hello-img/{{cookiecutter.project_name}}/hello_world/Dockerfile
@@ -1,14 +1,23 @@
-FROM public.ecr.aws/lambda/ruby:{{ cookiecutter.options[cookiecutter.runtime].version }}
+# building phase
+#
+FROM public.ecr.aws/sam/build-ruby{{ cookiecutter.options[cookiecutter.runtime].version }} as build-image
+
+ARG SCRATCH_DIR=/var/task/build
+
+ENV GEM_HOME=${SCRATCH_DIR}
 
 COPY app.rb Gemfile ./
+RUN bundle install
+RUN cp -r ${GEM_HOME}/* .
+RUN rm -r ${GEM_HOME}
+
+# runtime emulation phase
+#
+FROM public.ecr.aws/lambda/ruby:{{ cookiecutter.options[cookiecutter.runtime].version }}
 
 ENV GEM_HOME=${LAMBDA_TASK_ROOT}
 
-# Install dev tools so that `bigdecimal` (a dep of httparty) can be installed
-RUN yum install gcc make -y
-RUN bundle install
-# Remove the dev tools
-RUN yum remove gcc make -y
+COPY --from=build-image /var/task/ ./
 
-# Command can be overwritten by providing a different command in the template directly.
+# # Command can be overwritten by providing a different command in the template directly.
 CMD ["app.lambda_handler"]

--- a/ruby/hello-img/{{cookiecutter.project_name}}/hello_world/Dockerfile
+++ b/ruby/hello-img/{{cookiecutter.project_name}}/hello_world/Dockerfile
@@ -8,7 +8,7 @@ ENV GEM_HOME=${LAMBDA_TASK_ROOT}
 RUN yum install gcc make -y
 RUN bundle install
 # Remove the dev tools
-RUN yum uninstall gcc make -y
+RUN yum remove gcc make -y
 
 # Command can be overwritten by providing a different command in the template directly.
 CMD ["app.lambda_handler"]


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
A recent change to a downstream dependency of `httparty` (`multi_xml>=0.7.0`) now requires build tools to be installed inside of the image. In preparation of `bigdecimal` (another package, this time `multi_xml` requires) not being included in the Ruby 3.4 release, `multi_xml` adds `bigdecimal` explicitly as a dependency requiring a build.

We don't have build tools installed in the image. This fix changes the Dockerfile to adopt our build images to build the extension from source, then utilize the emulation runtime to run the Ruby function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
