### PR TITLE
chore: Remove lint tests for python3.8

### DIFF
--- a/tests/integration/build_invoke/python/test_python_3_8.py
+++ b/tests/integration/build_invoke/python/test_python_3_8.py
@@ -10,48 +10,70 @@ For each template, it will test the following sam commands:
 
 class BuildInvoke_python3_8_cookiecutter_aws_sam_hello_python(BuildInvokeBase.SimpleHelloWorldBuildInvokeBase):
     directory = "python3.8/hello"
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 
 class BuildInvoke_python3_8_cookiecutter_aws_sam_eventBridge_python(
     BuildInvokeBase.EventBridgeHelloWorldBuildInvokeBase
 ):
     directory = "python3.8/event-bridge"
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 
 class BuildInvoke_python3_8_cookiecutter_aws_sam_quick_start_web_with_connectors(BuildInvokeBase.QuickStartWebBuildInvokeBase):
     directory = "python3.8/web-conn"
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 
 class BuildInvoke_python3_8_cookiecutter_aws_sam_step_functions_with_connectors(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.8/step-func-conn"
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 
 @skip("eventbridge schema app requires credential to pull missing files, skip")
 class BuildInvoke_python3_8_cookiecutter_aws_sam_eventbridge_schema_app_python(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.8/event-bridge-schema"
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 
 class BuildInvoke_python3_8_cookiecutter_aws_sam_step_functions_sample_app(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.8/step-func"
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 
 class BuildInvoke_python3_8_cookiecutter_aws_sam_efs_python(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.8/efs"
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 class BuildInvoke_image_python3_8_cookiecutter_aws_sam_hello_python_lambda_image(
     BuildInvokeBase.SimpleHelloWorldBuildInvokeBase
 ):
     directory = "python3.8/hello-img"
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 class BuildInvoke_python3_8_cookiecutter_aws_sam_hello_pt_python(BuildInvokeBase.SimpleHelloWorldBuildInvokeBase):
     directory = "python3.8/hello-pt"
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 class BuildInvoke_python3_8_pytorch(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.8/apigw-pytorch"
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 
 class BuildInvoke_python3_8_tensorflow(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.8/apigw-tensorflow"
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 class BuildInvoke_python3_8_xgboost(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.8/apigw-xgboost"

--- a/tests/integration/unit_test/test_unit_test_python3_8.py
+++ b/tests/integration/unit_test/test_unit_test_python3_8.py
@@ -4,19 +4,27 @@ from tests.integration.unit_test.unit_test_base import UnitTestBase
 class UnitTest_python3_8_cookiecutter_aws_sam_hello_python(UnitTestBase.Python38UnitTestBase):
     directory = "python3.8/hello"
     code_directories = ["hello_world"]
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 class UnitTest_python3_8_cookiecutter_aws_sam_hello_pt_python(UnitTestBase.Python38UnitTestBase):
     directory = "python3.8/hello-pt"
     code_directories = ["hello_world"]
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 class UnitTest_python3_8_cookiecutter_aws_sam_eventBridge_python(UnitTestBase.Python38UnitTestBase):
     directory = "python3.8/event-bridge"
     code_directories = ["hello_world_function"]
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 
 class UnitTest_python3_8_cookiecutter_aws_sam_eventbridge_schema_app_python(UnitTestBase.Python38UnitTestBase):
     directory = "python3.8/event-bridge-schema"
     code_directories = ["hello_world_function"]
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
     def _test_unit_tests(self, code_directory: str):
         self.skipTest("eventbridge schema app requires credential to pull missing files, skip")
@@ -30,11 +38,15 @@ class UnitTest_python3_8_cookiecutter_aws_sam_step_functions_sample_app(UnitTest
         "functions/stock_checker",
         "functions/stock_seller",
     ]
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 
 class UnitTest_python3_8_cookiecutter_aws_sam_efs_python(UnitTestBase.Python38UnitTestBase):
     directory = "python3.8/efs"
     code_directories = ["hello_efs"]
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 
 class UnitTest_python3_8_cookiecutter_aws_sam_quick_start_web_with_connectors(UnitTestBase.Python38UnitTestBase):
@@ -44,6 +56,8 @@ class UnitTest_python3_8_cookiecutter_aws_sam_quick_start_web_with_connectors(Un
         "src/handlers/get_by_id", 
         "src/handlers/put_item"
     ]
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False
 
 
 class UnitTest_python3_8_cookiecutter_aws_sam_step_functions_with_connectors(UnitTestBase.Python38UnitTestBase):
@@ -53,3 +67,5 @@ class UnitTest_python3_8_cookiecutter_aws_sam_step_functions_with_connectors(Uni
         "functions/stock_checker",
         "functions/stock_seller",
     ]
+    # python3.8 is deprecated and linter throws an error
+    should_test_lint = False


### PR DESCRIPTION
*Description of changes:*

Remove lint tests for python3.8 to unblock GH action tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
