### PR TITLE
feat: add ruby3.4 support

### DIFF
--- a/.github/workflows/build_test_invoke.yml
+++ b/.github/workflows/build_test_invoke.yml
@@ -241,6 +241,13 @@ jobs:
           - version: '3.3'
             type: 'Invoke'
             file: 'tests/integration/build_invoke/ruby/test_ruby_3_3.py'
+          - version: '3.4'
+            type: 'Test'
+            file: 'tests/integration/unit_test/test_unit_test_ruby3_4.py'
+          # Uncomment after SAM CLI supports Ruby3.4 and the build image is available
+          # - version: '3.4'
+          #   type: 'Invoke'
+          #   file: 'tests/integration/build_invoke/ruby/test_ruby_3_4.py'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -1291,6 +1291,32 @@
       "useCaseName": "Serverless API"
     }
   ],
+  "ruby3.4": [
+    {
+      "directory": "ruby/hello",
+      "displayName": "Hello World Example",
+      "dependencyManager": "bundler",
+      "appTemplate": "hello-world",
+      "packageType": "Zip",
+      "useCaseName": "Hello World Example"
+    },
+    {
+      "directory": "ruby/step-func",
+      "displayName": "Step Functions Sample App (Stock Trader)",
+      "dependencyManager": "bundler",
+      "appTemplate": "step-functions-sample-app",
+      "packageType": "Zip",
+      "useCaseName": "Multi-step workflow"
+    },
+    {
+      "directory": "ruby/web",
+      "displayName": "Quick Start: Web Backend",
+      "dependencyManager": "bundler",
+      "appTemplate": "quick-start-web",
+      "packageType": "Zip",
+      "useCaseName": "Serverless API"
+    }
+  ],
   "rust (provided.al2)": [
     {
       "directory": "al2/rust/hello",
@@ -1508,6 +1534,16 @@
     }
   ],
   "amazon/ruby3.3-base": [
+    {
+      "directory": "ruby/hello-img",
+      "displayName": "Hello World Lambda Image Example",
+      "dependencyManager": "bundler",
+      "appTemplate": "hello-world-lambda-image",
+      "packageType": "Image",
+      "useCaseName": "Hello World Example"
+    }
+  ],
+  "amazon/ruby3.4-base": [
     {
       "directory": "ruby/hello-img",
       "displayName": "Hello World Lambda Image Example",

--- a/ruby/hello-img/cookiecutter.json
+++ b/ruby/hello-img/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "Name of the project",
-    "runtime": ["ruby3.2", "ruby3.3"],
+    "runtime": ["ruby3.2", "ruby3.3", "ruby3.4"],
     "architectures": {
         "value": [
             "x86_64", "arm64"
@@ -13,6 +13,10 @@
         },
         "ruby3.3": {
             "version": "3.3",
+            "memory_size": "512"
+        },
+        "ruby3.4": {
+            "version": "3.4",
             "memory_size": "512"
         }
     },

--- a/ruby/hello/cookiecutter.json
+++ b/ruby/hello/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "Name of the project",
-    "runtime": ["ruby3.2", "ruby3.3"],
+    "runtime": ["ruby3.2", "ruby3.3", "ruby3.4"],
     "architectures": {
         "value": [
             "x86_64", "arm64"
@@ -13,6 +13,10 @@
         },
         "ruby3.3": {
             "version": "3.3",
+            "memory_size": "512"
+        },
+        "ruby3.4": {
+            "version": "3.4",
             "memory_size": "512"
         }
     },

--- a/ruby/step-func/cookiecutter.json
+++ b/ruby/step-func/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "Name of the project",
-    "runtime": ["ruby3.2", "ruby3.3"],
+    "runtime": ["ruby3.2", "ruby3.3", "ruby3.4"],
     "architectures": {
         "value": [
             "x86_64", "arm64"
@@ -13,6 +13,10 @@
         },
         "ruby3.3": {
             "version": "3.3",
+            "memory_size": "512"
+        },
+        "ruby3.4": {
+            "version": "3.4",
             "memory_size": "512"
         }
     },

--- a/ruby/web/cookiecutter.json
+++ b/ruby/web/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "Name of the project",
-  "runtime": ["ruby3.2", "ruby3.3"],
+  "runtime": ["ruby3.2", "ruby3.3", "ruby3.4"],
   "architectures": {
       "value": [
           "x86_64", "arm64"
@@ -13,6 +13,10 @@
       },
       "ruby3.3": {
           "version": "3.3",
+          "memory_size": "512"
+      },
+      "ruby3.4": {
+          "version": "3.4",
           "memory_size": "512"
       }
   },

--- a/tests/integration/build_invoke/ruby/test_ruby_3_4.py
+++ b/tests/integration/build_invoke/ruby/test_ruby_3_4.py
@@ -24,6 +24,6 @@ class BuildInvoke_image_ruby3_4_cookiecutter_aws_sam_hello_ruby_lambda_image(
     runtime = "ruby3.4"
     directory = "ruby/hello-img"
 
-class BuildInvoke_image_ruby3_2_cookiecutter_aws_sam_quick_start_web(BuildInvokeBase.RubyQuickStartWebBuildInvokeBase):
+class BuildInvoke_image_ruby3_4_cookiecutter_aws_sam_quick_start_web(BuildInvokeBase.RubyQuickStartWebBuildInvokeBase):
     runtime = "ruby3.4"
     directory = "ruby/web"

--- a/tests/integration/build_invoke/ruby/test_ruby_3_4.py
+++ b/tests/integration/build_invoke/ruby/test_ruby_3_4.py
@@ -8,22 +8,22 @@ For each template, it will test the following sam commands:
 3. (if there are event jsons), for each event json, check `sam local invoke` response is a valid json
 """
 
-class BuildInvoke_ruby3_3_cookiecutter_aws_sam_hello_ruby(BuildInvokeBase.HelloWorldExclamationBuildInvokeBase):
-    runtime = "ruby3.3"
+class BuildInvoke_ruby3_4_cookiecutter_aws_sam_hello_ruby(BuildInvokeBase.HelloWorldExclamationBuildInvokeBase):
+    runtime = "ruby3.4"
     directory = "ruby/hello"
 
 
-class BuildInvoke_ruby3_3_cookiecutter_aws_sam_step_functions_sample_app(BuildInvokeBase.BuildInvokeBase):
-    runtime = "ruby3.3"
+class BuildInvoke_ruby3_4_cookiecutter_aws_sam_step_functions_sample_app(BuildInvokeBase.BuildInvokeBase):
+    runtime = "ruby3.4"
     directory = "ruby/step-func"
 
 
-class BuildInvoke_image_ruby3_3_cookiecutter_aws_sam_hello_ruby_lambda_image(
+class BuildInvoke_image_ruby3_4_cookiecutter_aws_sam_hello_ruby_lambda_image(
     BuildInvokeBase.HelloWorldExclamationBuildInvokeBase
 ):
-    runtime = "ruby3.3"
+    runtime = "ruby3.4"
     directory = "ruby/hello-img"
 
-class BuildInvoke_image_ruby3_3_cookiecutter_aws_sam_quick_start_web(BuildInvokeBase.RubyQuickStartWebBuildInvokeBase):
-    runtime = "ruby3.3"
+class BuildInvoke_image_ruby3_2_cookiecutter_aws_sam_quick_start_web(BuildInvokeBase.RubyQuickStartWebBuildInvokeBase):
+    runtime = "ruby3.4"
     directory = "ruby/web"

--- a/tests/integration/unit_test/test_unit_test_ruby3_4.py
+++ b/tests/integration/unit_test/test_unit_test_ruby3_4.py
@@ -1,0 +1,32 @@
+from tests.integration.unit_test.unit_test_base import UnitTestBase
+
+
+class UnitTest_ruby3_4_cookiecutter_aws_sam_hello_ruby(UnitTestBase.RubyUnitTestBase):
+    runtime = "ruby3.4"
+    directory = "ruby/hello"
+    code_directories = ["tests/unit/test_handler.rb"]
+    # It can be removed after cfn-lint supports ruby3.4
+    should_test_lint = False
+
+
+class UnitTest_ruby3_4_cookiecutter_aws_sam_step_functions_sample_app(UnitTestBase.RubyUnitTestBase):
+    runtime = "ruby3.4"
+    directory = "ruby/step-func"
+    should_test_lint = False
+    code_directories = [
+        "tests/unit/test_stock_buyer.rb",
+        "tests/unit/test_stock_checker.rb",
+        "tests/unit/test_stock_seller.rb",
+    ]
+
+class UnitTest_ruby3_4_cookiecutter_quick_start_web(UnitTestBase.RubyUnitTestBase):
+    runtime = "ruby3.4"
+    directory = "ruby/web"
+    should_test_lint = False
+    code_directories = [
+        "test/test_create_item.rb",
+        "test/test_delete_item.rb",
+        "test/test_get_all_items.rb",
+        "test/test_get_item_by_id.rb",
+        "test/test_update_item.rb"
+    ]

--- a/tests/integration/unit_test/test_unit_test_ruby3_4.py
+++ b/tests/integration/unit_test/test_unit_test_ruby3_4.py
@@ -5,7 +5,7 @@ class UnitTest_ruby3_4_cookiecutter_aws_sam_hello_ruby(UnitTestBase.RubyUnitTest
     runtime = "ruby3.4"
     directory = "ruby/hello"
     code_directories = ["tests/unit/test_handler.rb"]
-    # It can be removed after cfn-lint supports ruby3.4
+    # It can be removed after SAM CLI consumes cfn-lint 1.32.0, which adds support for ruby3.4
     should_test_lint = False
 
 


### PR DESCRIPTION
*Issue #, if available:*

Ruby 3.4 is coming soon: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-future

*Description of changes:*

Add new templates for Ruby 3.4, basically replicating the templates for Ruby 3.3. Previous PR to support Ruby 3.3 here: #494

Some integration tests won't work until build images are available.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
