### PR TITLE
chore: bump pytorch version

### DIFF
--- a/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -1,14 +1,14 @@
 {%- if cookiecutter.architectures.value|length == 1 and cookiecutter.architectures.value[0] == 'arm64' %}
-FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
+FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2
 {%- else %}
-FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
+FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2
 {%- endif %}
 
-# RUN yum -y update \
-#     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-#     less libcurl-devel openssl openssl-devel readline-devel xz-devel \
-#     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
-#     && rm -rf /var/cache/yum
+RUN yum -y update \
+    && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
+    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
+    zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
+    && rm -rf /var/cache/yum
 
 # Graal VM
 ENV JAVA_VERSION java11
@@ -34,12 +34,16 @@ RUN rm $GRALE_FILENAME
 ENV PATH=$PATH:/usr/lib/gradle/bin
 
 # AWS Lambda Builders
-# RUN amazon-linux-extras enable python3.9
-RUN dnf -y install python3.9 curl
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3.9 get-pip.py \
-    && rm get-pip.py
-RUN pip3 install aws-lambda-builders
+RUN cd /tmp \
+    && wget https://www.python.org/ftp/python/3.9.17/Python-3.9.17.tgz \
+    && tar xvf Python-3.9.17.tgz \
+    && cd Python-3.9.17 \
+    && ./configure --enable-optimizations \
+    && make install
+
+RUN python3 -m ensurepip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install aws-lambda-builders
 
 VOLUME /project
 WORKDIR /project

--- a/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -34,9 +34,9 @@ RUN rm $GRALE_FILENAME
 ENV PATH=$PATH:/usr/lib/gradle/bin
 
 # AWS Lambda Builders
-RUN amazon-linux-extras enable python3.8
-RUN yum clean metadata && yum -y install python3.8
-RUN curl -L get-pip.io | python3.8
+RUN amazon-linux-extras enable python3.9
+RUN yum clean metadata && yum -y install python3.9
+RUN curl -L get-pip.io | python3.9
 RUN pip3 install aws-lambda-builders
 
 VOLUME /project

--- a/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -6,7 +6,7 @@ FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2
 
 RUN yum -y update \
     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
+    less libcurl-devel openssl openssl-devel readline-devel xz-devel wget \
     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
     && rm -rf /var/cache/yum
 

--- a/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -1,7 +1,7 @@
 {%- if cookiecutter.architectures.value|length == 1 and cookiecutter.architectures.value[0] == 'arm64' %}
-FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2
+FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- else %}
-FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2
+FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- endif %}
 
 RUN yum -y update \
@@ -34,7 +34,8 @@ RUN rm $GRALE_FILENAME
 ENV PATH=$PATH:/usr/lib/gradle/bin
 
 # AWS Lambda Builders
-RUN amazon-linux-extras enable python3.9
+# RUN amazon-linux-extras enable python3.9
+RUN dnf -y install python3.9
 RUN yum clean metadata && yum -y install python3.9
 RUN curl -L get-pip.io | python3.9
 RUN pip3 install aws-lambda-builders

--- a/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -4,11 +4,11 @@ FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
 FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- endif %}
 
-RUN yum -y update \
-    && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
-    zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
-    && rm -rf /var/cache/yum
+# RUN yum -y update \
+#     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
+#     less libcurl-devel openssl openssl-devel readline-devel xz-devel \
+#     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
+#     && rm -rf /var/cache/yum
 
 # Graal VM
 ENV JAVA_VERSION java11
@@ -35,9 +35,10 @@ ENV PATH=$PATH:/usr/lib/gradle/bin
 
 # AWS Lambda Builders
 # RUN amazon-linux-extras enable python3.9
-RUN dnf -y install python3.9
-RUN yum clean metadata && yum -y install python3.9
-RUN curl -L get-pip.io | python3.9
+RUN dnf -y install python3.9 curl
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3.9 get-pip.py \
+    && rm get-pip.py
 RUN pip3 install aws-lambda-builders
 
 VOLUME /project

--- a/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -1,14 +1,14 @@
 {%- if cookiecutter.architectures.value|length == 1 and cookiecutter.architectures.value[0] == 'arm64' %}
-FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
+FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2
 {%- else %}
-FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
+FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2
 {%- endif %}
 
-# RUN yum -y update \
-#     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-#     less libcurl-devel openssl openssl-devel readline-devel xz-devel \
-#     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
-#     && rm -rf /var/cache/yum
+RUN yum -y update \
+    && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
+    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
+    zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
+    && rm -rf /var/cache/yum
 
 # Graal VM
 ENV JAVA_VERSION java11
@@ -32,12 +32,16 @@ RUN mv $MVN_FOLDERNAME /usr/lib/maven
 RUN rm -rf $MVN_FOLDERNAME
 
 # AWS Lambda Builders
-# RUN amazon-linux-extras enable python3.9
-# RUN yum clean metadata && yum -y install python3.9
-RUN dnf -y install python3.9 curl
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3.9 get-pip.py \
-    && rm get-pip.pyRUN pip3 install aws-lambda-builders
+RUN cd /tmp \
+    && wget https://www.python.org/ftp/python/3.9.17/Python-3.9.17.tgz \
+    && tar xvf Python-3.9.17.tgz \
+    && cd Python-3.9.17 \
+    && ./configure --enable-optimizations \
+    && make install
+
+RUN python3 -m ensurepip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install aws-lambda-builders
 
 VOLUME /project
 WORKDIR /project

--- a/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -1,7 +1,7 @@
 {%- if cookiecutter.architectures.value|length == 1 and cookiecutter.architectures.value[0] == 'arm64' %}
-FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2
+FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- else %}
-FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2
+FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- endif %}
 
 RUN yum -y update \
@@ -32,7 +32,7 @@ RUN mv $MVN_FOLDERNAME /usr/lib/maven
 RUN rm -rf $MVN_FOLDERNAME
 
 # AWS Lambda Builders
-RUN amazon-linux-extras enable python3.9
+# RUN amazon-linux-extras enable python3.9
 RUN yum clean metadata && yum -y install python3.9
 RUN curl -L get-pip.io | python3.9
 RUN pip3 install aws-lambda-builders

--- a/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -4,11 +4,11 @@ FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
 FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- endif %}
 
-RUN yum -y update \
-    && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
-    zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
-    && rm -rf /var/cache/yum
+# RUN yum -y update \
+#     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
+#     less libcurl-devel openssl openssl-devel readline-devel xz-devel \
+#     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
+#     && rm -rf /var/cache/yum
 
 # Graal VM
 ENV JAVA_VERSION java11
@@ -33,9 +33,11 @@ RUN rm -rf $MVN_FOLDERNAME
 
 # AWS Lambda Builders
 # RUN amazon-linux-extras enable python3.9
-RUN yum clean metadata && yum -y install python3.9
-RUN curl -L get-pip.io | python3.9
-RUN pip3 install aws-lambda-builders
+# RUN yum clean metadata && yum -y install python3.9
+RUN dnf -y install python3.9 curl
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3.9 get-pip.py \
+    && rm get-pip.pyRUN pip3 install aws-lambda-builders
 
 VOLUME /project
 WORKDIR /project

--- a/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -24,7 +24,7 @@ RUN mv $GRAAL_FOLDERNAME /usr/lib/graalvm
 RUN rm -rf $GRAAL_FOLDERNAME
 
 # Maven
-ENV MVN_VERSION 3.8.8
+ENV MVN_VERSION 3.9.10
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz

--- a/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -6,7 +6,7 @@ FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2
 
 RUN yum -y update \
     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
+    less libcurl-devel openssl openssl-devel readline-devel xz-devel wget \
     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
     && rm -rf /var/cache/yum
 

--- a/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -32,9 +32,9 @@ RUN mv $MVN_FOLDERNAME /usr/lib/maven
 RUN rm -rf $MVN_FOLDERNAME
 
 # AWS Lambda Builders
-RUN amazon-linux-extras enable python3.8
-RUN yum clean metadata && yum -y install python3.8
-RUN curl -L get-pip.io | python3.8
+RUN amazon-linux-extras enable python3.9
+RUN yum clean metadata && yum -y install python3.9
+RUN curl -L get-pip.io | python3.9
 RUN pip3 install aws-lambda-builders
 
 VOLUME /project

--- a/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -1,14 +1,14 @@
 {%- if cookiecutter.architectures.value|length == 1 and cookiecutter.architectures.value[0] == 'arm64' %}
-FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
+FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2
 {%- else %}
-FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
+FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2
 {%- endif %}
 
-# RUN dnf install -y python3.9 curl tar unzip
-RUN dnf clean metadata && \
-    dnf install -y python3.9 curl tar unzip && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
+RUN yum -y update \
+    && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
+    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
+    zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
+    && rm -rf /var/cache/yum
 
 # Graal VM
 ENV JAVA_VERSION java17
@@ -34,10 +34,16 @@ RUN rm $GRALE_FILENAME
 ENV PATH=$PATH:/usr/lib/gradle/bin
 
 # AWS Lambda Builders
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3.9 get-pip.py \
-    && rm get-pip.py
-RUN pip3 install aws-lambda-builders
+RUN cd /tmp \
+    && wget https://www.python.org/ftp/python/3.9.17/Python-3.9.17.tgz \
+    && tar xvf Python-3.9.17.tgz \
+    && cd Python-3.9.17 \
+    && ./configure --enable-optimizations \
+    && make install
+
+RUN python3 -m ensurepip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install aws-lambda-builders
 
 VOLUME /project
 WORKDIR /project

--- a/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -34,9 +34,9 @@ RUN rm $GRALE_FILENAME
 ENV PATH=$PATH:/usr/lib/gradle/bin
 
 # AWS Lambda Builders
-RUN amazon-linux-extras enable python3.8
-RUN yum clean metadata && yum -y install python3.8
-RUN curl -L get-pip.io | python3.8
+RUN amazon-linux-extras enable python3.9
+RUN yum clean metadata && yum -y install python3.9
+RUN curl -L get-pip.io | python3.9
 RUN pip3 install aws-lambda-builders
 
 VOLUME /project

--- a/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -4,11 +4,7 @@ FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
 FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- endif %}
 
-# RUN yum -y update \
-#     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-#     less libcurl-devel openssl openssl-devel readline-devel xz-devel \
-#     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
-#     && rm -rf /var/cache/yum
+RUN dnf -y update && dnf install -y python3.9 curl tar unzip
 
 # Graal VM
 ENV JAVA_VERSION java17
@@ -34,9 +30,6 @@ RUN rm $GRALE_FILENAME
 ENV PATH=$PATH:/usr/lib/gradle/bin
 
 # AWS Lambda Builders
-# RUN amazon-linux-extras enable python3.9
-# RUN yum clean metadata && yum -y install python3.9
-RUN dnf -y install python3.9 curl
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && python3.9 get-pip.py \
     && rm get-pip.py

--- a/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -6,7 +6,7 @@ FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2
 
 RUN yum -y update \
     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
+    less libcurl-devel openssl openssl-devel readline-devel xz-devel wget \
     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
     && rm -rf /var/cache/yum
 

--- a/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -1,7 +1,7 @@
 {%- if cookiecutter.architectures.value|length == 1 and cookiecutter.architectures.value[0] == 'arm64' %}
-FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2
+FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- else %}
-FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2
+FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- endif %}
 
 RUN yum -y update \
@@ -34,7 +34,8 @@ RUN rm $GRALE_FILENAME
 ENV PATH=$PATH:/usr/lib/gradle/bin
 
 # AWS Lambda Builders
-RUN amazon-linux-extras enable python3.9
+# RUN amazon-linux-extras enable python3.9
+RUN dnf -y install python3.9
 RUN yum clean metadata && yum -y install python3.9
 RUN curl -L get-pip.io | python3.9
 RUN pip3 install aws-lambda-builders

--- a/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -4,11 +4,11 @@ FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
 FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- endif %}
 
-RUN yum -y update \
-    && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
-    zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
-    && rm -rf /var/cache/yum
+# RUN yum -y update \
+#     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
+#     less libcurl-devel openssl openssl-devel readline-devel xz-devel \
+#     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
+#     && rm -rf /var/cache/yum
 
 # Graal VM
 ENV JAVA_VERSION java17
@@ -35,9 +35,11 @@ ENV PATH=$PATH:/usr/lib/gradle/bin
 
 # AWS Lambda Builders
 # RUN amazon-linux-extras enable python3.9
-RUN dnf -y install python3.9
-RUN yum clean metadata && yum -y install python3.9
-RUN curl -L get-pip.io | python3.9
+# RUN yum clean metadata && yum -y install python3.9
+RUN dnf -y install python3.9 curl
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3.9 get-pip.py \
+    && rm get-pip.py
 RUN pip3 install aws-lambda-builders
 
 VOLUME /project

--- a/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -4,7 +4,11 @@ FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
 FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- endif %}
 
-RUN dnf -y update && dnf install -y python3.9 curl tar unzip
+# RUN dnf install -y python3.9 curl tar unzip
+RUN dnf clean metadata && \
+    dnf install -y python3.9 curl tar unzip && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 # Graal VM
 ENV JAVA_VERSION java17

--- a/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -33,9 +33,9 @@ RUN mv $MVN_FOLDERNAME /usr/lib/maven
 RUN rm -rf $MVN_FOLDERNAME
 
 # AWS Lambda Builders
-RUN amazon-linux-extras enable python3.8
-RUN yum clean metadata && yum -y install python3.8
-RUN curl -L get-pip.io | python3.8
+RUN amazon-linux-extras enable python3.9
+RUN yum clean metadata && yum -y install python3.9
+RUN curl -L get-pip.io | python3.9
 RUN pip3 install aws-lambda-builders
 
 VOLUME /project

--- a/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -4,11 +4,11 @@ FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
 FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- endif %}
 
-RUN yum -y update \
-    && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
-    zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
-    && rm -rf /var/cache/yum
+# RUN yum -y update \
+#     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
+#     less libcurl-devel openssl openssl-devel readline-devel xz-devel \
+#     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
+#     && rm -rf /var/cache/yum
 
 # Graal VM
 ENV JAVA_VERSION java17
@@ -34,10 +34,11 @@ RUN rm -rf $MVN_FOLDERNAME
 
 # AWS Lambda Builders
 # RUN amazon-linux-extras enable python3.9 //extras only has 3.8 and below. maybe use al2023? but that doesnt have extras. 
-RUN dnf -y install python3.9
-
-RUN yum clean metadata && yum -y install python3.9
-RUN curl -L get-pip.io | python3.9
+# RUN yum clean metadata && yum -y install python3.9
+RUN dnf -y install python3.9 curl
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3.9 get-pip.py \
+    && rm get-pip.py
 RUN pip3 install aws-lambda-builders
 
 VOLUME /project

--- a/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -6,7 +6,7 @@ FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2
 
 RUN yum -y update \
     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
+    less libcurl-devel openssl openssl-devel readline-devel xz-devel wget \
     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
     && rm -rf /var/cache/yum
 

--- a/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -25,7 +25,7 @@ RUN rm -rf $GRAAL_FOLDERNAME
 
 
 # Maven
-ENV MVN_VERSION 3.8.8
+ENV MVN_VERSION 3.9.10
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz

--- a/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -1,7 +1,7 @@
 {%- if cookiecutter.architectures.value|length == 1 and cookiecutter.architectures.value[0] == 'arm64' %}
-FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2
+FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- else %}
-FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2
+FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
 {%- endif %}
 
 RUN yum -y update \
@@ -33,7 +33,9 @@ RUN mv $MVN_FOLDERNAME /usr/lib/maven
 RUN rm -rf $MVN_FOLDERNAME
 
 # AWS Lambda Builders
-RUN amazon-linux-extras enable python3.9
+# RUN amazon-linux-extras enable python3.9 //extras only has 3.8 and below. maybe use al2023? but that doesnt have extras. 
+RUN dnf -y install python3.9
+
 RUN yum clean metadata && yum -y install python3.9
 RUN curl -L get-pip.io | python3.9
 RUN pip3 install aws-lambda-builders

--- a/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -1,14 +1,14 @@
 {%- if cookiecutter.architectures.value|length == 1 and cookiecutter.architectures.value[0] == 'arm64' %}
-FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2023
+FROM --platform=linux/arm64 public.ecr.aws/amazonlinux/amazonlinux:2
 {%- else %}
-FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
+FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2
 {%- endif %}
 
-# RUN yum -y update \
-#     && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-#     less libcurl-devel openssl openssl-devel readline-devel xz-devel \
-#     zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
-#     && rm -rf /var/cache/yum
+RUN yum -y update \
+    && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
+    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
+    zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
+    && rm -rf /var/cache/yum
 
 # Graal VM
 ENV JAVA_VERSION java17
@@ -33,13 +33,16 @@ RUN mv $MVN_FOLDERNAME /usr/lib/maven
 RUN rm -rf $MVN_FOLDERNAME
 
 # AWS Lambda Builders
-# RUN amazon-linux-extras enable python3.9 //extras only has 3.8 and below. maybe use al2023? but that doesnt have extras. 
-# RUN yum clean metadata && yum -y install python3.9
-RUN dnf -y install python3.9 curl
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3.9 get-pip.py \
-    && rm get-pip.py
-RUN pip3 install aws-lambda-builders
+RUN cd /tmp \
+    && wget https://www.python.org/ftp/python/3.9.17/Python-3.9.17.tgz \
+    && tar xvf Python-3.9.17.tgz \
+    && cd Python-3.9.17 \
+    && ./configure --enable-optimizations \
+    && make install
+
+RUN python3 -m ensurepip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install aws-lambda-builders
 
 VOLUME /project
 WORKDIR /project

--- a/python3.10/apigw-pytorch/cookiecutter.json
+++ b/python3.10/apigw-pytorch/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "project_name": "digit_classifier",
   "pytorch_version": "2.6.0",
-  "torchvision_version": "0.14.1",
+  "torchvision_version": "0.21.0",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [

--- a/python3.10/apigw-pytorch/cookiecutter.json
+++ b/python3.10/apigw-pytorch/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "digit_classifier",
-  "pytorch_version": "1.13.1",
+  "pytorch_version": "2.6.0",
   "torchvision_version": "0.14.1",
   "api_path": "/classify_digit",
   "architectures": {

--- a/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
--f https://download.pytorch.org/whl/torch/
+-f https://download.pytorch.org/whl/cpu
 torch=={{cookiecutter.pytorch_version}}+cpu
 torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,5 @@
--f https://download.pytorch.org/whl/cpu
+--index-url https://download.pytorch.org/whl/cpu
+--extra-index-url https://pypi.org/simple
 torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
-torch=={{cookiecutter.pytorch_version}}+cpu
+# TODO: add version+cpu after it is released
+torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
 -f https://download.pytorch.org/whl/cpu
-torch=={{cookiecutter.pytorch_version}}+cpu
-torchvision=={{cookiecutter.torchvision_version}}+cpu
+torch=={{cookiecutter.pytorch_version}}
+torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,5 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 # TODO: add version+cpu after it is released
 torch=={{cookiecutter.pytorch_version}}
-torchvision=={{cookiecutter.torchvision_version}}+cpu
+torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,5 +1,4 @@
--f https://download.pytorch.org/whl/torch_stable.html
-# TODO: add version+cpu after it is released
-torch=={{cookiecutter.pytorch_version}}
-torchvision=={{cookiecutter.torchvision_version}}
+-f https://download.pytorch.org/whl/torch/
+torch=={{cookiecutter.pytorch_version}}+cpu
+torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.11/apigw-pytorch/cookiecutter.json
+++ b/python3.11/apigw-pytorch/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "project_name": "digit_classifier",
   "pytorch_version": "2.6.0",
-  "torchvision_version": "0.15.1",
+  "torchvision_version": "0.21.0",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [

--- a/python3.11/apigw-pytorch/cookiecutter.json
+++ b/python3.11/apigw-pytorch/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "digit_classifier",
-  "pytorch_version": "2.0.0",
+  "pytorch_version": "2.6.0",
   "torchvision_version": "0.15.1",
   "api_path": "/classify_digit",
   "architectures": {

--- a/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,6 +1,5 @@
--f https://download.pytorch.org/whl/torch_stable.html
-# TODO: add version+cpu after it is released
-torch=={{cookiecutter.pytorch_version}}
-torchvision=={{cookiecutter.torchvision_version}}
+-f https://download.pytorch.org/whl/torch/
+torch=={{cookiecutter.pytorch_version}}+cpu
+torchvision=={{cookiecutter.torchvision_version}}+cpu
 numpy==1.26.4
 pillow

--- a/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
--f https://download.pytorch.org/whl/torch/
+-f https://download.pytorch.org/whl/cpu
 torch=={{cookiecutter.pytorch_version}}+cpu
 torchvision=={{cookiecutter.torchvision_version}}+cpu
 numpy==1.26.4

--- a/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,5 +1,5 @@
 -f https://download.pytorch.org/whl/cpu
-torch=={{cookiecutter.pytorch_version}}+cpu
-torchvision=={{cookiecutter.torchvision_version}}+cpu
+torch=={{cookiecutter.pytorch_version}}
+torchvision=={{cookiecutter.torchvision_version}}
 numpy==1.26.4
 pillow

--- a/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,5 @@
--f https://download.pytorch.org/whl/cpu
+--index-url https://download.pytorch.org/whl/cpu
+--extra-index-url https://pypi.org/simple
 torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}
 numpy==1.26.4

--- a/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
-torch=={{cookiecutter.pytorch_version}}+cpu
+# TODO: add version+cpu after it is released
+torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,5 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 # TODO: add version+cpu after it is released
 torch=={{cookiecutter.pytorch_version}}
-torchvision=={{cookiecutter.torchvision_version}}+cpu
+torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -2,4 +2,5 @@
 # TODO: add version+cpu after it is released
 torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}
+numpy==1.26.4
 pillow

--- a/python3.11/apigw-scikit/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-scikit/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,2 +1,3 @@
 scikit-learn=={{cookiecutter.scikit_learn_version}}
+numpy==1.26.4
 pillow

--- a/python3.11/apigw-tensorflow/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-tensorflow/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,2 +1,3 @@
 tensorflow=={{cookiecutter.tensorflow_version}}
+numpy==1.26.4
 pillow

--- a/python3.11/apigw-tensorflow/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-tensorflow/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,3 +1,3 @@
 tensorflow=={{cookiecutter.tensorflow_version}}
-numpy==1.26.4
+numpy==1.24
 pillow

--- a/python3.11/apigw-xgboost/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-xgboost/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,2 +1,3 @@
 xgboost=={{cookiecutter.xgboost_version}}
+numpy==1.26.4
 pillow

--- a/python3.12/apigw-pytorch/cookiecutter.json
+++ b/python3.12/apigw-pytorch/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "project_name": "digit_classifier",
   "pytorch_version": "2.6.0",
-  "torchvision_version": "0.15.1",
+  "torchvision_version": "0.21.0",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [

--- a/python3.12/apigw-pytorch/cookiecutter.json
+++ b/python3.12/apigw-pytorch/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "digit_classifier",
-  "pytorch_version": "2.0.0",
+  "pytorch_version": "2.6.0",
   "torchvision_version": "0.15.1",
   "api_path": "/classify_digit",
   "architectures": {

--- a/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
--f https://download.pytorch.org/whl/torch/
+-f https://download.pytorch.org/whl/cpu
 torch=={{cookiecutter.pytorch_version}}+cpu
 torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,5 @@
--f https://download.pytorch.org/whl/cpu
+--index-url https://download.pytorch.org/whl/cpu
+--extra-index-url https://pypi.org/simple
 torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
-torch=={{cookiecutter.pytorch_version}}+cpu
+# TODO: add version+cpu after it is released
+torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
 -f https://download.pytorch.org/whl/cpu
-torch=={{cookiecutter.pytorch_version}}+cpu
-torchvision=={{cookiecutter.torchvision_version}}+cpu
+torch=={{cookiecutter.pytorch_version}}
+torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,5 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 # TODO: add version+cpu after it is released
 torch=={{cookiecutter.pytorch_version}}
-torchvision=={{cookiecutter.torchvision_version}}+cpu
+torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,5 +1,4 @@
--f https://download.pytorch.org/whl/torch_stable.html
-# TODO: add version+cpu after it is released
-torch=={{cookiecutter.pytorch_version}}
-torchvision=={{cookiecutter.torchvision_version}}
+-f https://download.pytorch.org/whl/torch/
+torch=={{cookiecutter.pytorch_version}}+cpu
+torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.13/apigw-pytorch/cookiecutter.json
+++ b/python3.13/apigw-pytorch/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "project_name": "digit_classifier",
   "pytorch_version": "2.6.0",
-  "torchvision_version": "0.15.1",
+  "torchvision_version": "0.21.0",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [

--- a/python3.13/apigw-pytorch/cookiecutter.json
+++ b/python3.13/apigw-pytorch/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "digit_classifier",
-  "pytorch_version": "2.0.0",
+  "pytorch_version": "2.6.0",
   "torchvision_version": "0.15.1",
   "api_path": "/classify_digit",
   "architectures": {

--- a/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
--f https://download.pytorch.org/whl/torch/
+-f https://download.pytorch.org/whl/cpu
 torch=={{cookiecutter.pytorch_version}}+cpu
 torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,5 @@
--f https://download.pytorch.org/whl/cpu
+--index-url https://download.pytorch.org/whl/cpu
+--extra-index-url https://pypi.org/simple
 torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
-torch=={{cookiecutter.pytorch_version}}+cpu
+# TODO: add version+cpu after it is released
+torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
 -f https://download.pytorch.org/whl/cpu
-torch=={{cookiecutter.pytorch_version}}+cpu
-torchvision=={{cookiecutter.torchvision_version}}+cpu
+torch=={{cookiecutter.pytorch_version}}
+torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,5 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 # TODO: add version+cpu after it is released
 torch=={{cookiecutter.pytorch_version}}
-torchvision=={{cookiecutter.torchvision_version}}+cpu
+torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,5 +1,4 @@
--f https://download.pytorch.org/whl/torch_stable.html
-# TODO: add version+cpu after it is released
-torch=={{cookiecutter.pytorch_version}}
-torchvision=={{cookiecutter.torchvision_version}}
+-f https://download.pytorch.org/whl/torch/
+torch=={{cookiecutter.pytorch_version}}+cpu
+torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.9/apigw-pytorch/cookiecutter.json
+++ b/python3.9/apigw-pytorch/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "project_name": "digit_classifier",
   "pytorch_version": "2.6.0",
-  "torchvision_version": "0.14.1",
+  "torchvision_version": "0.21.0",
   "api_path": "/classify_digit",
   "architectures": {
     "value": [

--- a/python3.9/apigw-pytorch/cookiecutter.json
+++ b/python3.9/apigw-pytorch/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "digit_classifier",
-  "pytorch_version": "1.13.1",
+  "pytorch_version": "2.6.0",
   "torchvision_version": "0.14.1",
   "api_path": "/classify_digit",
   "architectures": {

--- a/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
--f https://download.pytorch.org/whl/torch_stable.html
-torch=={{cookiecutter.pytorch_version}}
-torchvision=={{cookiecutter.torchvision_version}}
+-f https://download.pytorch.org/whl/torch/
+torch=={{cookiecutter.pytorch_version}}+cpu
+torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
--f https://download.pytorch.org/whl/torch/
+-f https://download.pytorch.org/whl/cpu
 torch=={{cookiecutter.pytorch_version}}+cpu
 torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,5 +1,4 @@
 -f https://download.pytorch.org/whl/torch_stable.html
-# TODO: add version+cpu after it is released
 torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,5 @@
--f https://download.pytorch.org/whl/cpu
+--index-url https://download.pytorch.org/whl/cpu
+--extra-index-url https://pypi.org/simple
 torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
-torch=={{cookiecutter.pytorch_version}}+cpu
+# TODO: add version+cpu after it is released
+torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}+cpu
 pillow

--- a/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,4 @@
 -f https://download.pytorch.org/whl/cpu
-torch=={{cookiecutter.pytorch_version}}+cpu
-torchvision=={{cookiecutter.torchvision_version}}+cpu
+torch=={{cookiecutter.pytorch_version}}
+torchvision=={{cookiecutter.torchvision_version}}
 pillow

--- a/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,5 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 # TODO: add version+cpu after it is released
 torch=={{cookiecutter.pytorch_version}}
-torchvision=={{cookiecutter.torchvision_version}}+cpu
+torchvision=={{cookiecutter.torchvision_version}}
 pillow


### PR DESCRIPTION
*Issue #, if available:*
Bump pytorch version to 2.6.0. This newest version does not have a +cpu wheel in https://download.pytorch.org/whl/torch_stable.html so we can add it when it is released in the future. Also pinned numpy version based on what torchvision and tensorflow require.

Also fixed java al2 templates as the dockerfile was still using python3.8.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
