### PR TITLE
Fix hardcoded AWS endpoint using CloudFormation pseudo parameter

### DIFF
--- a/al2/go/hello-img/{{cookiecutter.project_name}}/template.yaml
+++ b/al2/go/hello-img/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldAPI:
     Description: "API Gateway endpoint URL for Prod environment for First Function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "First Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/al2/go/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/al2/go/hello/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldAPI:
     Description: "API Gateway endpoint URL for Prod environment for First Function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "First Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/template.yaml
@@ -38,7 +38,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com/"
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/al2/graalvm/11/maven/{{cookiecutter.project_name}}/template.yaml
+++ b/al2/graalvm/11/maven/{{cookiecutter.project_name}}/template.yaml
@@ -38,7 +38,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com/"
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/template.yaml
@@ -38,7 +38,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com/"
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/al2/graalvm/17/maven/{{cookiecutter.project_name}}/template.yaml
+++ b/al2/graalvm/17/maven/{{cookiecutter.project_name}}/template.yaml
@@ -38,7 +38,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com/"
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/al2/rust/hello/{{ cookiecutter.project_slug }}/template.yaml
+++ b/al2/rust/hello/{{ cookiecutter.project_slug }}/template.yaml
@@ -40,7 +40,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/al2023/go/hello-img/{{cookiecutter.project_name}}/template.yaml
+++ b/al2023/go/hello-img/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldAPI:
     Description: "API Gateway endpoint URL for Prod environment for First Function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "First Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/al2023/go/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/al2023/go/hello/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldAPI:
     Description: "API Gateway endpoint URL for Prod environment for First Function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "First Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/al2023/rust/hello/{{ cookiecutter.project_slug }}/template.yaml
+++ b/al2023/rust/hello/{{ cookiecutter.project_slug }}/template.yaml
@@ -40,7 +40,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/dotnet6/hello-img/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet6/hello-img/{{cookiecutter.project_name}}/template.yaml
@@ -33,7 +33,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/dotnet6/hello-ps/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet6/hello-ps/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/dotnet6/hello-pt/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet6/hello-pt/{{cookiecutter.project_name}}/template.yaml
@@ -64,7 +64,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/dotnet6/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet6/hello/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/dotnet6/web/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet6/web/{{cookiecutter.project_name}}/template.yaml
@@ -53,4 +53,4 @@ Resources:
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL"
-    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com/"
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/"

--- a/dotnet8/hello-img/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet8/hello-img/{{cookiecutter.project_name}}/template.yaml
@@ -33,7 +33,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/dotnet8/hello-native-aot/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet8/hello-native-aot/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldAotApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldAotFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldAotFunction.Arn

--- a/dotnet8/hello-pt/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet8/hello-pt/{{cookiecutter.project_name}}/template.yaml
@@ -64,7 +64,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/dotnet8/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet8/hello/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/dotnet8/web/{{cookiecutter.project_name}}/template.yaml
+++ b/dotnet8/web/{{cookiecutter.project_name}}/template.yaml
@@ -53,4 +53,4 @@ Resources:
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL"
-    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com/"
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/"

--- a/java11/hello-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/hello-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java11/hello-img-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/hello-img-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java11/hello-img-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/hello-img-maven/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java11/hello-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/hello-maven/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java11/hello-pt-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/hello-pt-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -45,7 +45,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java11/hello-pt-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java11/hello-pt-maven/{{cookiecutter.project_name}}/template.yaml
@@ -47,7 +47,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java17/hello-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java17/hello-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -41,7 +41,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java17/hello-img-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java17/hello-img-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java17/hello-img-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java17/hello-img-maven/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java17/hello-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java17/hello-maven/{{cookiecutter.project_name}}/template.yaml
@@ -41,7 +41,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java17/hello-pt-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java17/hello-pt-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -45,7 +45,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java17/hello-pt-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java17/hello-pt-maven/{{cookiecutter.project_name}}/template.yaml
@@ -45,7 +45,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java21/hello-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java21/hello-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -41,7 +41,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java21/hello-img-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java21/hello-img-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java21/hello-img-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java21/hello-img-maven/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java21/hello-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java21/hello-maven/{{cookiecutter.project_name}}/template.yaml
@@ -41,7 +41,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java8.al2/hello-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/hello-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java8.al2/hello-img-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/hello-img-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java8.al2/hello-img-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/hello-img-maven/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java8.al2/hello-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/hello-maven/{{cookiecutter.project_name}}/template.yaml
@@ -42,7 +42,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/java8.al2/hello-pt-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/java8.al2/hello-pt-maven/{{cookiecutter.project_name}}/template.yaml
@@ -47,7 +47,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/nodejs20.x/full-stack/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs20.x/full-stack/{{cookiecutter.project_name}}/template.yaml
@@ -232,7 +232,7 @@ Resources:
 Outputs:
   APIGatewayEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${ApiGatewayApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Value: !Sub "https://${ApiGatewayApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/"
   CloudFrontDistributionId:
     Description: "CloudFront Distribution ID for hosting web front end"
     Value: !Ref CloudFrontDistribution

--- a/nodejs20.x/hello-img/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs20.x/hello-img/{{cookiecutter.project_name}}/template.yaml
@@ -38,7 +38,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/nodejs20.x/hello-ts-pt/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs20.x/hello-ts-pt/{{cookiecutter.project_name}}/template.yaml
@@ -61,7 +61,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/nodejs20.x/hello-ts/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs20.x/hello-ts/{{cookiecutter.project_name}}/template.yaml
@@ -44,7 +44,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/nodejs20.x/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs20.x/hello/{{cookiecutter.project_name}}/template.yaml
@@ -36,7 +36,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/nodejs20.x/web/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs20.x/web/{{cookiecutter.project_name}}/template.yaml
@@ -128,4 +128,4 @@ Resources:
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/"

--- a/nodejs22.x/full-stack/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs22.x/full-stack/{{cookiecutter.project_name}}/template.yaml
@@ -232,7 +232,7 @@ Resources:
 Outputs:
   APIGatewayEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${ApiGatewayApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Value: !Sub "https://${ApiGatewayApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/"
   CloudFrontDistributionId:
     Description: "CloudFront Distribution ID for hosting web front end"
     Value: !Ref CloudFrontDistribution

--- a/nodejs22.x/hello-img/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs22.x/hello-img/{{cookiecutter.project_name}}/template.yaml
@@ -38,7 +38,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/nodejs22.x/hello-ts-pt/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs22.x/hello-ts-pt/{{cookiecutter.project_name}}/template.yaml
@@ -61,7 +61,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/nodejs22.x/hello-ts/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs22.x/hello-ts/{{cookiecutter.project_name}}/template.yaml
@@ -44,7 +44,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/nodejs22.x/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs22.x/hello/{{cookiecutter.project_name}}/template.yaml
@@ -36,7 +36,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/nodejs22.x/web/{{cookiecutter.project_name}}/template.yaml
+++ b/nodejs22.x/web/{{cookiecutter.project_name}}/template.yaml
@@ -128,4 +128,4 @@ Resources:
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/"

--- a/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.10/apigw-scikit/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.10/apigw-scikit/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.10/apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.10/apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.10/apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.10/apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.10/efs/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.10/efs/{{cookiecutter.project_name}}/template.yaml
@@ -110,4 +110,4 @@ Resources:
 Outputs:
   HelloEfsApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello EFS function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"

--- a/python3.10/hello-img/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.10/hello-img/{{cookiecutter.project_name}}/template.yaml
@@ -38,7 +38,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/python3.10/hello-pt/{{ cookiecutter.project_name }}/template.yaml
+++ b/python3.10/hello-pt/{{ cookiecutter.project_name }}/template.yaml
@@ -53,7 +53,7 @@ Resources:
 Outputs:
     HelloWorldApi:
       Description: "API Gateway endpoint URL for Prod environment for Hello World Function"
-      Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello"
+      Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello"
 
     HelloWorldFunction:
       Description: "Hello World Lambda Function ARN"

--- a/python3.10/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.10/hello/{{cookiecutter.project_name}}/template.yaml
@@ -36,7 +36,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/python3.10/web-conn/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.10/web-conn/{{cookiecutter.project_name}}/template.yaml
@@ -128,4 +128,4 @@ Resources:
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/"

--- a/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.11/apigw-scikit/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.11/apigw-scikit/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.11/apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.11/apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.11/apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.11/apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.11/efs/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.11/efs/{{cookiecutter.project_name}}/template.yaml
@@ -110,4 +110,4 @@ Resources:
 Outputs:
   HelloEfsApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello EFS function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"

--- a/python3.11/hello-img/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.11/hello-img/{{cookiecutter.project_name}}/template.yaml
@@ -38,7 +38,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/python3.11/hello-pt/{{ cookiecutter.project_name }}/template.yaml
+++ b/python3.11/hello-pt/{{ cookiecutter.project_name }}/template.yaml
@@ -53,7 +53,7 @@ Resources:
 Outputs:
     HelloWorldApi:
       Description: "API Gateway endpoint URL for Prod environment for Hello World Function"
-      Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello"
+      Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello"
 
     HelloWorldFunction:
       Description: "Hello World Lambda Function ARN"

--- a/python3.11/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.11/hello/{{cookiecutter.project_name}}/template.yaml
@@ -36,7 +36,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/python3.11/web-conn/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.11/web-conn/{{cookiecutter.project_name}}/template.yaml
@@ -128,4 +128,4 @@ Resources:
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/"

--- a/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.12/apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.12/apigw-scikit/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.12/apigw-scikit/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.12/apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.12/apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.12/apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.12/apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.12/efs/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.12/efs/{{cookiecutter.project_name}}/template.yaml
@@ -110,4 +110,4 @@ Resources:
 Outputs:
   HelloEfsApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello EFS function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"

--- a/python3.12/hello-img/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.12/hello-img/{{cookiecutter.project_name}}/template.yaml
@@ -38,7 +38,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/python3.12/hello-pt/{{ cookiecutter.project_name }}/template.yaml
+++ b/python3.12/hello-pt/{{ cookiecutter.project_name }}/template.yaml
@@ -53,7 +53,7 @@ Resources:
 Outputs:
     HelloWorldApi:
       Description: "API Gateway endpoint URL for Prod environment for Hello World Function"
-      Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello"
+      Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello"
 
     HelloWorldFunction:
       Description: "Hello World Lambda Function ARN"

--- a/python3.12/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.12/hello/{{cookiecutter.project_name}}/template.yaml
@@ -36,7 +36,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/python3.12/web-conn/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.12/web-conn/{{cookiecutter.project_name}}/template.yaml
@@ -128,4 +128,4 @@ Resources:
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/"

--- a/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.13/apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.13/apigw-scikit/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.13/apigw-scikit/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.13/apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.13/apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.13/apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.13/apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.13/efs/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.13/efs/{{cookiecutter.project_name}}/template.yaml
@@ -110,4 +110,4 @@ Resources:
 Outputs:
   HelloEfsApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello EFS function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"

--- a/python3.13/hello-img/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.13/hello-img/{{cookiecutter.project_name}}/template.yaml
@@ -38,7 +38,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/python3.13/hello-pt/{{ cookiecutter.project_name }}/template.yaml
+++ b/python3.13/hello-pt/{{ cookiecutter.project_name }}/template.yaml
@@ -53,7 +53,7 @@ Resources:
 Outputs:
     HelloWorldApi:
       Description: "API Gateway endpoint URL for Prod environment for Hello World Function"
-      Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello"
+      Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello"
 
     HelloWorldFunction:
       Description: "Hello World Lambda Function ARN"

--- a/python3.13/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.13/hello/{{cookiecutter.project_name}}/template.yaml
@@ -36,7 +36,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/python3.13/web-conn/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.13/web-conn/{{cookiecutter.project_name}}/template.yaml
@@ -128,4 +128,4 @@ Resources:
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/"

--- a/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.9/apigw-pytorch/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.9/apigw-scikit/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.9/apigw-scikit/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.9/apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.9/apigw-tensorflow/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.9/apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.9/apigw-xgboost/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   InferenceApi:
     Description: "API Gateway endpoint URL for Prod stage for Inference function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod{{cookiecutter.api_path}}/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod{{cookiecutter.api_path}}/"
   InferenceFunction:
     Description: "Inference Lambda Function ARN"
     Value: !GetAtt InferenceFunction.Arn

--- a/python3.9/efs/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.9/efs/{{cookiecutter.project_name}}/template.yaml
@@ -110,4 +110,4 @@ Resources:
 Outputs:
   HelloEfsApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello EFS function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"

--- a/python3.9/hello-img/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.9/hello-img/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/python3.9/hello-pt/{{ cookiecutter.project_name }}/template.yaml
+++ b/python3.9/hello-pt/{{ cookiecutter.project_name }}/template.yaml
@@ -53,7 +53,7 @@ Resources:
 Outputs:
     HelloWorldApi:
       Description: "API Gateway endpoint URL for Prod environment for Hello World Function"
-      Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello"
+      Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello"
 
     HelloWorldFunction:
       Description: "Hello World Lambda Function ARN"

--- a/python3.9/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.9/hello/{{cookiecutter.project_name}}/template.yaml
@@ -37,7 +37,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/python3.9/web-conn/{{cookiecutter.project_name}}/template.yaml
+++ b/python3.9/web-conn/{{cookiecutter.project_name}}/template.yaml
@@ -128,4 +128,4 @@ Resources:
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/"

--- a/ruby/hello-img/{{cookiecutter.project_name}}/template.yaml
+++ b/ruby/hello-img/{{cookiecutter.project_name}}/template.yaml
@@ -39,7 +39,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/ruby/hello/{{cookiecutter.project_name}}/template.yaml
+++ b/ruby/hello/{{cookiecutter.project_name}}/template.yaml
@@ -37,7 +37,7 @@ Outputs:
   # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
   HelloWorldApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/hello/"
   HelloWorldFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt HelloWorldFunction.Arn

--- a/ruby/web/{{cookiecutter.project_name}}/template.yaml
+++ b/ruby/web/{{cookiecutter.project_name}}/template.yaml
@@ -132,4 +132,4 @@ Resources:
 Outputs:
   WebEndpoint:
     Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}/Prod/"


### PR DESCRIPTION
Hardcoded endpoints such as `amazonaws.com` are incompatible with custom endpoint URLs (e.g., `AWS_ENDPOINT_URL`): https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html
* This breaks non-standard AWS partitions (https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/partitions.html) such as `aws-us-gov`
* This breaks emulator compatibility, such as LocalStack

Using the CloudFormation pseudo parameter `${AWS::URLSuffix}` (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-urlsuffix) fixes this issue. 

*Issue #, if available:* N/A

*Description of changes:* Replace hardcoded `amazonaws.com` domain in `template.yaml` output value with `${AWS::URLSuffix}`. The parameter `${AWS::URLSuffix}` evaluates to `amazonaws.com` in most cases, but respects custom endpoint URLs used, for example, in emulators such as LocalStack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Testing:*

Setup: Have LocalStack installed https://docs.localstack.cloud/aws/getting-started/installation/

1. Apply the template using SAM CLI: `sam init --no-input --location aws-sam-cli-app-templates/python3.11/hello --name sam-python-11-hello`
2. Start LocalStack: `localstack start`
3. Deploy SAM application: `AWS_ENDPOINT_URL=http://localhost.localstack.cloud:4566 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 sam deploy`
4. Check SAM outputs: `AWS_ENDPOINT_URL=http://localhost.localstack.cloud:4566 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 sam list stack-outputs --output json `
5. Ensure that the output value for `HelloWorldApi` is invokable `curl https://bpvf06fjhb.execute-api.localhost.localstack.cloud:4566/Prod/hello/`

Disclaimer: I work for LocalStack
