### PR TITLE
fix: use java project wrapper version

### DIFF
--- a/.github/workflows/build_test_invoke.yml
+++ b/.github/workflows/build_test_invoke.yml
@@ -167,7 +167,6 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: ${{ matrix.version }}
-          gradle-version: '8.14'
       - name: Run build tests for ${{ matrix.file }}
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/build_test_invoke.yml
+++ b/.github/workflows/build_test_invoke.yml
@@ -167,6 +167,7 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: ${{ matrix.version }}
+          gradle-version: '8.14'
       - name: Run build tests for ${{ matrix.file }}
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -73,6 +73,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -24,7 +24,7 @@ RUN mv $GRAAL_FOLDERNAME /usr/lib/graalvm
 RUN rm -rf $GRAAL_FOLDERNAME
 
 # Maven
-ENV MVN_VERSION 3.9.11
+ENV MVN_VERSION 3.9.10
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz

--- a/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -24,7 +24,7 @@ RUN mv $GRAAL_FOLDERNAME /usr/lib/graalvm
 RUN rm -rf $GRAAL_FOLDERNAME
 
 # Maven
-ENV MVN_VERSION 3.9.10
+ENV MVN_VERSION 3.9.11
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz

--- a/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -25,7 +25,7 @@ RUN rm -rf $GRAAL_FOLDERNAME
 
 
 # Maven
-ENV MVN_VERSION 3.9.10
+ENV MVN_VERSION 3.9.11
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz

--- a/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -25,7 +25,7 @@ RUN rm -rf $GRAAL_FOLDERNAME
 
 
 # Maven
-ENV MVN_VERSION 3.9.11
+ENV MVN_VERSION 3.9.10
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz

--- a/tests/integration/unit_test/unit_test_base.py
+++ b/tests/integration/unit_test/unit_test_base.py
@@ -137,7 +137,7 @@ class UnitTestBase:
             pass
 
         def _test_unit_tests(self, code_directory: str):
-            cmdlist = ["gradle", "test"]
+            cmdlist = ["./gradlew", "test"]
             LOG.info(cmdlist)
             result = run_command(cmdlist, Path(self.cwd, code_directory))
             self.assertIn("BUILD SUCCESSFUL", result.stdout)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
use java project wrapper version for gradle instead of global gradle version to avoid auto installing gradle version 9.0.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
