### PR TITLE
fix: miscellaneous fixes for CI failures

### DIFF
--- a/.github/actions/aws-sam-cli-develop/action.yml
+++ b/.github/actions/aws-sam-cli-develop/action.yml
@@ -17,5 +17,3 @@ runs:
         samdev --info
       name: Install AWS SAM CLI as samdev
       shell: bash
-      env:
-        UV_PYTHON: python${{ env.PYTHON_VERSION_INSTALL }}

--- a/.github/actions/aws-sam-cli-develop/action.yml
+++ b/.github/actions/aws-sam-cli-develop/action.yml
@@ -17,3 +17,5 @@ runs:
         samdev --info
       name: Install AWS SAM CLI as samdev
       shell: bash
+      env:
+        UV_PYTHON: python${{ env.PYTHON_VERSION_INSTALL }}

--- a/.github/workflows/build_test_invoke.yml
+++ b/.github/workflows/build_test_invoke.yml
@@ -75,9 +75,11 @@ jobs:
           - version: '3.9'
             type: 'Test'
             file: 'tests/integration/unit_test/test_unit_test_python3_9.py'
+            sam_cli_python: '3.11'
           - version: '3.9'
             type: 'Invoke'
             file: 'tests/integration/build_invoke/python/test_python_3_9.py'
+            sam_cli_python: '3.11'
           - version: '3.10'
             type: 'Test'
             file: 'tests/integration/unit_test/test_unit_test_python3_10.py'
@@ -109,7 +111,7 @@ jobs:
           #   type: 'Invoke'
           #   file: 'tests/integration/build_invoke/python/test_python_3_14.py'            
     env:
-      PYTHON_VERSION_INSTALL: ${{ matrix.version }}
+      PYTHON_VERSION_INSTALL: ${{ matrix.sam_cli_python || matrix.version }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -13,6 +13,7 @@ RUN yum -y update \
 # Graal VM
 ENV JAVA_VERSION java11
 ENV GRAAL_VERSION 22.1.0
+ENV JAVA_TOOL_OPTIONS -XX:-UseContainerSupport
 ENV GRAAL_FOLDERNAME graalvm-ce-${JAVA_VERSION}-${GRAAL_VERSION}
 {%- if cookiecutter.architectures.value|length == 1 and cookiecutter.architectures.value[0] == 'arm64' %}
 ENV GRAAL_FILENAME graalvm-ce-${JAVA_VERSION}-linux-aarch64-${GRAAL_VERSION}.tar.gz

--- a/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -24,7 +24,7 @@ RUN mv $GRAAL_FOLDERNAME /usr/lib/graalvm
 RUN rm -rf $GRAAL_FOLDERNAME
 
 # Maven
-ENV MVN_VERSION 3.9.12
+ENV MVN_VERSION 3.9.15
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz

--- a/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/11/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -13,6 +13,7 @@ RUN yum -y update \
 # Graal VM
 ENV JAVA_VERSION java11
 ENV GRAAL_VERSION 22.1.0
+ENV JAVA_TOOL_OPTIONS -XX:-UseContainerSupport
 ENV GRAAL_FOLDERNAME graalvm-ce-${JAVA_VERSION}-${GRAAL_VERSION}
 {%- if cookiecutter.architectures.value|length == 1 and cookiecutter.architectures.value[0] == 'arm64' %}
 ENV GRAAL_FILENAME graalvm-ce-${JAVA_VERSION}-linux-aarch64-${GRAAL_VERSION}.tar.gz

--- a/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/gradle/{{cookiecutter.project_name}}/Dockerfile
@@ -13,6 +13,7 @@ RUN yum -y update \
 # Graal VM
 ENV JAVA_VERSION java17
 ENV GRAAL_VERSION 22.1.0
+ENV JAVA_TOOL_OPTIONS -XX:-UseContainerSupport
 ENV GRAAL_FOLDERNAME graalvm-ce-${JAVA_VERSION}-${GRAAL_VERSION}
 {%- if cookiecutter.architectures.value|length == 1 and cookiecutter.architectures.value[0] == 'arm64' %}
 ENV GRAAL_FILENAME graalvm-ce-${JAVA_VERSION}-linux-aarch64-${GRAAL_VERSION}.tar.gz

--- a/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -11,7 +11,7 @@ RUN yum -y update \
     && rm -rf /var/cache/yum
 
 # Maven
-ENV MVN_VERSION 3.9.12
+ENV MVN_VERSION 3.9.15
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz

--- a/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
+++ b/al2/graalvm/17/maven/{{cookiecutter.project_name}}/Dockerfile
@@ -21,6 +21,7 @@ RUN rm -rf $MVN_FOLDERNAME
 # Graal VM
 ENV JAVA_VERSION java17
 ENV GRAAL_VERSION 22.1.0
+ENV JAVA_TOOL_OPTIONS -XX:-UseContainerSupport
 ENV GRAAL_FOLDERNAME graalvm-ce-${JAVA_VERSION}-${GRAAL_VERSION}
 {%- if cookiecutter.architectures.value|length == 1 and cookiecutter.architectures.value[0] == 'arm64' %}
 ENV GRAAL_FILENAME graalvm-ce-${JAVA_VERSION}-linux-aarch64-${GRAAL_VERSION}.tar.gz

--- a/python3.11/apigw-scikit/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-scikit/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,6 @@
 scikit-learn=={{cookiecutter.scikit_learn_version}}
 numpy==1.26.4
+# Pinning to 1.16.0 because major versions above this don't ship with manylinux 2014 wheels.
+# This is a problem because AL2 base images don't have a GCC new enough to build transient dep numpy from source.
 scipy<=1.16.0
 pillow

--- a/python3.11/apigw-scikit/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-scikit/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,3 +1,4 @@
 scikit-learn=={{cookiecutter.scikit_learn_version}}
 numpy==1.26.4
+scipy<=1.16.0
 pillow

--- a/python3.11/apigw-xgboost/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-xgboost/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,4 +1,6 @@
 xgboost=={{cookiecutter.xgboost_version}}
 numpy==1.26.4
+# Pinning to 1.16.0 because major versions above this don't ship with manylinux 2014 wheels.
+# This is a problem because AL2 base images don't have a GCC new enough to build transient dep numpy from source.
 scipy<=1.16.0
 pillow

--- a/python3.11/apigw-xgboost/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-xgboost/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,3 +1,4 @@
 xgboost=={{cookiecutter.xgboost_version}}
 numpy==1.26.4
+scipy<=1.16.0
 pillow

--- a/tests/integration/build_invoke/python/test_python_3_9.py
+++ b/tests/integration/build_invoke/python/test_python_3_9.py
@@ -10,35 +10,43 @@ For each template, it will test the following sam commands:
 
 class BuildInvoke_python3_9_cookiecutter_aws_sam_hello_python(BuildInvokeBase.SimpleHelloWorldBuildInvokeBase):
     directory = "python3.9/hello"
+    should_test_lint = False
 
 
 class BuildInvoke_python3_9_cookiecutter_aws_sam_eventBridge_python(
     BuildInvokeBase.EventBridgeHelloWorldBuildInvokeBase
 ):
     directory = "python3.9/event-bridge"
+    should_test_lint = False
 
 class BuildInvoke_python3_9_cookiecutter_aws_sam_quick_start_web_with_connectors(BuildInvokeBase.QuickStartWebBuildInvokeBase):
     directory = "python3.9/web-conn"
+    should_test_lint = False
 
 
 class BuildInvoke_python3_9_cookiecutter_aws_sam_step_functions_with_connectors(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.9/step-func-conn"
+    should_test_lint = False
 
 
 @skip("eventbridge schema app requires credential to pull missing files, skip")
 class BuildInvoke_python3_9_cookiecutter_aws_sam_eventbridge_schema_app_python(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.9/event-bridge-schema"
+    should_test_lint = False
 
 
 class BuildInvoke_python3_9_cookiecutter_aws_sam_step_functions_sample_app(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.9/step-func"
+    should_test_lint = False
 
 
 class BuildInvoke_python3_9_cookiecutter_aws_sam_efs_python(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.9/efs"
+    should_test_lint = False
 
 class BuildInvoke_python3_9_cookiecutter_aws_sam_hello_pt_python(BuildInvokeBase.SimpleHelloWorldBuildInvokeBase):
     directory = "python3.9/hello-pt"
+    should_test_lint = False
 
 
 # if we want to check response json, we need to setup efs
@@ -47,14 +55,20 @@ class BuildInvoke_image_python3_9_cookiecutter_aws_sam_hello_python_lambda_image
     BuildInvokeBase.SimpleHelloWorldBuildInvokeBase
 ):
     directory = "python3.9/hello-img"
+    should_test_lint = False
+
 class BuildInvoke_python3_9_pytorch(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.9/apigw-pytorch"
+    should_test_lint = False
 
 class BuildInvoke_python3_9_scikit(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.9/apigw-scikit"
+    should_test_lint = False
 
 class BuildInvoke_python3_9_tensorflow(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.9/apigw-tensorflow"
+    should_test_lint = False
 
 class BuildInvoke_python3_9_xgboost(BuildInvokeBase.BuildInvokeBase):
     directory = "python3.9/apigw-xgboost"
+    should_test_lint = False

--- a/tests/integration/build_invoke/ruby/test_ruby_3_2.py
+++ b/tests/integration/build_invoke/ruby/test_ruby_3_2.py
@@ -11,11 +11,13 @@ For each template, it will test the following sam commands:
 class BuildInvoke_ruby3_2_cookiecutter_aws_sam_hello_ruby(BuildInvokeBase.HelloWorldExclamationBuildInvokeBase):
     runtime = "ruby3.2"
     directory = "ruby/hello"
+    should_test_lint = False
 
 
 class BuildInvoke_ruby3_2_cookiecutter_aws_sam_step_functions_sample_app(BuildInvokeBase.BuildInvokeBase):
     runtime = "ruby3.2"
     directory = "ruby/step-func"
+    should_test_lint = False
 
 
 class BuildInvoke_image_ruby3_2_cookiecutter_aws_sam_hello_ruby_lambda_image(
@@ -23,7 +25,9 @@ class BuildInvoke_image_ruby3_2_cookiecutter_aws_sam_hello_ruby_lambda_image(
 ):
     runtime = "ruby3.2"
     directory = "ruby/hello-img"
+    should_test_lint = False
 
 class BuildInvoke_image_ruby3_2_cookiecutter_aws_sam_quick_start_web(BuildInvokeBase.RubyQuickStartWebBuildInvokeBase):
     runtime = "ruby3.2"
     directory = "ruby/web"
+    should_test_lint = False

--- a/tests/integration/unit_test/test_unit_test_ruby3_2.py
+++ b/tests/integration/unit_test/test_unit_test_ruby3_2.py
@@ -5,6 +5,7 @@ class UnitTest_ruby3_2_cookiecutter_aws_sam_hello_ruby(UnitTestBase.RubyUnitTest
     runtime = "ruby3.2"
     directory = "ruby/hello"
     code_directories = ["tests/unit/test_handler.rb"]
+    should_test_lint = False
 
 
 class UnitTest_ruby3_2_cookiecutter_aws_sam_step_functions_sample_app(UnitTestBase.RubyUnitTestBase):
@@ -15,6 +16,7 @@ class UnitTest_ruby3_2_cookiecutter_aws_sam_step_functions_sample_app(UnitTestBa
         "tests/unit/test_stock_checker.rb",
         "tests/unit/test_stock_seller.rb",
     ]
+    should_test_lint = False
 
 class UnitTest_ruby3_2_cookiecutter_quick_start_web(UnitTestBase.RubyUnitTestBase):
     runtime = "ruby3.2"
@@ -26,3 +28,4 @@ class UnitTest_ruby3_2_cookiecutter_quick_start_web(UnitTestBase.RubyUnitTestBas
         "test/test_get_item_by_id.rb",
         "test/test_update_item.rb"
     ]
+    should_test_lint = False

--- a/tests/integration/unit_test/unit_test_base.py
+++ b/tests/integration/unit_test/unit_test_base.py
@@ -118,6 +118,7 @@ class UnitTestBase:
 
     class Python39UnitTestBase(PythonUnitTestBase):
         python_executable = "python3.9"
+        should_test_lint = False
 
     class Python310UnitTestBase(PythonUnitTestBase):
         python_executable = "python3.10"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**Python 3.9 test and invoke**: These jobs were failing because the Python version that uv was picking up had a mismatch with the version we're trying to build (3.9). The fix is to have 3.11 as the version for SAM CLI and 3.9 as the version for the function runtimes. Example failure: https://github.com/aws/aws-sam-cli-app-templates/actions/runs/24679618608/job/72767286909?pr=546.

**Python 3.11 invoke**: numpy (a transient dependency of one of the templates), can't be compiled in the runner because it doesn't have a new enough version of gcc. This wasn't an issue before, but it seems like a new version of scipy is being used that doesn't come as a wheel anymore (1.17.1), which means we must compile numpy now. I've pinned scipy to <=1.16 so we can keep using a manylinux2014 wheel.

**AL2 Java**: We hardcode the Maven version into the dockerfiles. We needed to update this. There's also an issue that is identical to https://github.com/oracle/graal/issues/4831, fixed by following the guidance there and putting `ENV JAVA_TOOL_OPTIONS -XX:-UseContainerSupport`

**Ruby 3.2**: This is deprecated so calling `sam validate --lint` is failing. There's a flag to not lint, which I applied to Ruby 3.2 and Python 3.9 tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
