### PR TITLE
fix: pin pillow and dotnet Lambda.Tools to fix CI failures

### DIFF
--- a/dotnet6/hello-img/{{cookiecutter.project_name}}/src/HelloWorld/Dockerfile
+++ b/dotnet6/hello-img/{{cookiecutter.project_name}}/src/HelloWorld/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get -y install zip
 RUN mkdir $FUNCTION_DIR
 WORKDIR $FUNCTION_DIR
 COPY Function.cs HelloWorld.csproj aws-lambda-tools-defaults.json $FUNCTION_DIR/
-RUN dotnet tool install -g Amazon.Lambda.Tools
+RUN dotnet tool install -g Amazon.Lambda.Tools --version 5.14.0
 
 # Build and Copy artifacts depending on build mode.
 RUN mkdir -p build_artifacts

--- a/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.10/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -2,4 +2,5 @@
 --extra-index-url https://pypi.org/simple
 torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}
-pillow
+# Pinning pillow to avoid compilation issues (newer versions don't ship manylinux2014 wheels)
+pillow<=12.2.0

--- a/python3.10/apigw-scikit/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.10/apigw-scikit/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,2 +1,3 @@
 scikit-learn=={{cookiecutter.scikit_learn_version}}
-pillow
+# Pinning pillow to avoid compilation issues (newer versions don't ship manylinux2014 wheels)
+pillow<=12.2.0

--- a/python3.10/apigw-xgboost/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.10/apigw-xgboost/{{cookiecutter.project_name}}/app/requirements.txt
@@ -1,2 +1,3 @@
 xgboost=={{cookiecutter.xgboost_version}}
-pillow
+# Pinning pillow to avoid compilation issues (newer versions don't ship manylinux2014 wheels)
+pillow<=12.2.0

--- a/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-pytorch/{{cookiecutter.project_name}}/app/requirements.txt
@@ -3,4 +3,5 @@
 torch=={{cookiecutter.pytorch_version}}
 torchvision=={{cookiecutter.torchvision_version}}
 numpy==1.26.4
-pillow
+# Pinning pillow to avoid compilation issues (newer versions don't ship manylinux2014 wheels)
+pillow<=12.2.0

--- a/python3.11/apigw-scikit/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-scikit/{{cookiecutter.project_name}}/app/requirements.txt
@@ -3,4 +3,5 @@ numpy==1.26.4
 # Pinning to 1.16.0 because major versions above this don't ship with manylinux 2014 wheels.
 # This is a problem because AL2 base images don't have a GCC new enough to build transient dep numpy from source.
 scipy<=1.16.0
-pillow
+# Pinning pillow to avoid compilation issues (newer versions don't ship manylinux2014 wheels)
+pillow<=12.2.0

--- a/python3.11/apigw-xgboost/{{cookiecutter.project_name}}/app/requirements.txt
+++ b/python3.11/apigw-xgboost/{{cookiecutter.project_name}}/app/requirements.txt
@@ -3,4 +3,5 @@ numpy==1.26.4
 # Pinning to 1.16.0 because major versions above this don't ship with manylinux 2014 wheels.
 # This is a problem because AL2 base images don't have a GCC new enough to build transient dep numpy from source.
 scipy<=1.16.0
-pillow
+# Pinning pillow to avoid compilation issues (newer versions don't ship manylinux2014 wheels)
+pillow<=12.2.0


### PR DESCRIPTION
- Pin pillow<=12.2.0 for python3.10 and python3.11 ML templates (scikit, pytorch, xgboost). pillow 12.3.0 has no manylinux2014 wheel, requiring gcc compilation which is not available in Lambda base images.
- Pin Amazon.Lambda.Tools to 5.14.0 for dotnet6 image template. Version 7.0.0 dropped .NET 6 support.

*Issue #, if available:*
N/A — pre-existing CI failures

*Description of changes:*

Fix CI build failures in python3.10/3.11 ML templates and dotnet6 image template:

- **pillow<=12.2.0**: pillow 12.3.0 does not ship a manylinux2014 wheel, causing pip to download the source tarball and attempt compilation with gcc (which is not available in Lambda base images).
Pinning to <=12.2.0 ensures a pre-built wheel is used.
- **Amazon.Lambda.Tools --version 5.14.0**: Version 7.0.0 dropped .NET 6.0 support, breaking the dotnet6 image build. Pinning to the last compatible version.

Affected templates:
- python3.10: apigw-scikit, apigw-pytorch, apigw-xgboost
- python3.11: apigw-scikit, apigw-pytorch, apigw-xgboost
- dotnet6: hello-img

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
